### PR TITLE
fix: allow interactive table headers

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/table.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/table.ex
@@ -114,10 +114,19 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Table do
     <:col :let={r} label="Name">
       {r.name}
     </:col>
+
+    <:col
+      :let={r}
+      label="Select row"
+      header={~H[<input type="checkbox" aria-label="Select all rows" />]}
+    >
+      {r.name}
+    </:col>
     ```
     """
   ) do
     attr(:label, :string, doc: "table column title")
+    attr(:header, :any, doc: "rendered table column header content")
     attr(:label_class, :any, doc: "table column title CSS classes")
     attr(:class, :any, doc: "table row column class")
   end
@@ -170,7 +179,7 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Table do
             role="columnheader"
             scope="col"
             class={col[:label_class]}
-          >{col.label}</th>
+          >{col[:header] || col.label}</th>
         </tr>
       </thead>
       <tbody :if={@stream} id={@id && "#{@id}-stream-body"} phx-update="stream">

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/table_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/table_test.exs
@@ -63,6 +63,30 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.TableTest do
     end
   end
 
+  defmodule InteractiveHeaderComponent do
+    use Phoenix.Component
+    import PhoenixDuskmoon.Component.DataDisplay.Table
+
+    attr(:data, :list, default: [])
+
+    def render(assigns) do
+      header =
+        ~H"""
+        <input type="checkbox" aria-label="Select all rows" aria-checked="mixed" />
+        """
+
+      assigns = assign(assigns, :header, header)
+
+      ~H"""
+      <.dm_table data={@data}>
+        <:col :let={row} label="Select row" header={@header}>
+          {row.name}
+        </:col>
+      </.dm_table>
+      """
+    end
+  end
+
   describe "dm_table component" do
     test "renders basic table with data" do
       result =
@@ -92,6 +116,18 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.TableTest do
       assert result =~ ">Name<"
       assert result =~ ">Age<"
       assert result =~ ">City<"
+    end
+
+    test "renders interactive column header content while retaining the responsive label" do
+      result =
+        render_component(&InteractiveHeaderComponent.render/1, %{
+          data: @test_data
+        })
+
+      assert result =~ ~s[type="checkbox"]
+      assert result =~ ~s[aria-label="Select all rows"]
+      assert result =~ ~s[aria-checked="mixed"]
+      assert result =~ ~s[data-label="Select row"]
     end
 
     test "renders table with custom id and class" do


### PR DESCRIPTION
## Summary
- allow each `dm_table` column to render optional rich header content
- retain the string label for simple headers and responsive cell `data-label` values
- cover an interactive mixed-state checkbox header with a focused regression test

## Validation
- `MIX_ENV=test mix test test/phoenix_duskmoon/component/data_display/table_test.exs`
- `MIX_ENV=test mix compile --warnings-as-errors` (from `apps/phoenix_duskmoon`)
- `mix format --check-formatted`
- `git diff --check`

Fixes #145