### PR TITLE
fix: preserve parent-relative glob imports

### DIFF
--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/transforms/glob_imports.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/transforms/glob_imports.ex
@@ -226,18 +226,37 @@ defmodule DuskmoonBundler.JS.Transforms.GlobImports do
   defp wildcard(pattern, base_dir, base) do
     key_base_dir = key_base_dir(base, base_dir)
 
-    Path.join(base_dir, pattern)
+    Path.expand(pattern, base_dir)
     |> Path.wildcard()
     |> Enum.map(fn path ->
       %DuskmoonBundler.JS.Transforms.GlobImports.File{
-        specifier: "./" <> Path.relative_to(path, base_dir),
-        key: "./" <> Path.relative_to(path, key_base_dir)
+        specifier: relative_specifier(path, base_dir),
+        key: relative_specifier(path, key_base_dir)
       }
     end)
   end
 
   defp key_base_dir(nil, base_dir), do: base_dir
   defp key_base_dir(base, base_dir), do: Path.expand(base, base_dir)
+
+  defp relative_specifier(path, from_dir) do
+    {from_rest, path_rest} =
+      drop_shared_segments(
+        Path.split(Path.expand(from_dir)),
+        Path.split(Path.expand(path))
+      )
+
+    relative_path =
+      (List.duplicate("..", length(from_rest)) ++ path_rest)
+      |> Enum.join("/")
+
+    if String.starts_with?(relative_path, "../"), do: relative_path, else: "./" <> relative_path
+  end
+
+  defp drop_shared_segments([segment | from_rest], [segment | path_rest]),
+    do: drop_shared_segments(from_rest, path_rest)
+
+  defp drop_shared_segments(from_rest, path_rest), do: {from_rest, path_rest}
 
   defp lazy_expansion(files, call) do
     files

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/js/transforms/glob_imports.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/js/transforms/glob_imports.ex
@@ -226,7 +226,9 @@ defmodule DuskmoonBundler.JS.Transforms.GlobImports do
   defp wildcard(pattern, base_dir, base) do
     key_base_dir = key_base_dir(base, base_dir)
 
-    Path.expand(pattern, base_dir)
+    base_dir
+    |> Path.join(pattern)
+    |> Path.expand()
     |> Path.wildcard()
     |> Enum.map(fn path ->
       %DuskmoonBundler.JS.Transforms.GlobImports.File{
@@ -240,23 +242,15 @@ defmodule DuskmoonBundler.JS.Transforms.GlobImports do
   defp key_base_dir(base, base_dir), do: Path.expand(base, base_dir)
 
   defp relative_specifier(path, from_dir) do
-    {from_rest, path_rest} =
-      drop_shared_segments(
-        Path.split(Path.expand(from_dir)),
-        Path.split(Path.expand(path))
-      )
-
     relative_path =
-      (List.duplicate("..", length(from_rest)) ++ path_rest)
+      path
+      |> Path.expand()
+      |> Path.relative_to(Path.expand(from_dir), force: true)
+      |> Path.split()
       |> Enum.join("/")
 
     if String.starts_with?(relative_path, "../"), do: relative_path, else: "./" <> relative_path
   end
-
-  defp drop_shared_segments([segment | from_rest], [segment | path_rest]),
-    do: drop_shared_segments(from_rest, path_rest)
-
-  defp drop_shared_segments(from_rest, path_rest), do: {from_rest, path_rest}
 
   defp lazy_expansion(files, call) do
     files

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/js/transforms/glob_imports_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/js/transforms/glob_imports_test.exs
@@ -2,12 +2,21 @@ defmodule DuskmoonBundler.JS.Transforms.GlobImportsTest do
   use ExUnit.Case, async: true
 
   @fixture_dir Path.expand("fixtures/glob", __DIR__)
+  @parent_fixture_dir Path.expand("fixtures/glob_parent", __DIR__)
 
   setup do
     File.mkdir_p!(Path.join(@fixture_dir, "pages"))
     File.write!(Path.join(@fixture_dir, "pages/home.ts"), "export const name = 'home'")
     File.write!(Path.join(@fixture_dir, "pages/about.ts"), "export const name = 'about'")
-    on_exit(fn -> File.rm_rf!(@fixture_dir) end)
+    File.mkdir_p!(@parent_fixture_dir)
+    File.write!(Path.join(@parent_fixture_dir, "home.ts"), "export const name = 'home'")
+    File.write!(Path.join(@parent_fixture_dir, "about.ts"), "export const name = 'about'")
+
+    on_exit(fn ->
+      File.rm_rf!(@fixture_dir)
+      File.rm_rf!(@parent_fixture_dir)
+    end)
+
     :ok
   end
 
@@ -39,6 +48,17 @@ defmodule DuskmoonBundler.JS.Transforms.GlobImportsTest do
       assert result =~ "() => import("
       refute result =~ "import.meta.glob"
     end
+
+    test "preserves parent-relative paths and exclusions" do
+      source =
+        "const modules = import.meta.glob(['../glob_parent/*.ts', '!../glob_parent/about.ts'])"
+
+      result = DuskmoonBundler.JS.Transforms.GlobImports.transform(source, @fixture_dir)
+
+      assert result =~ ~S("../glob_parent/home.ts":)
+      assert result =~ ~S|import("../glob_parent/home.ts")|
+      refute result =~ "glob_parent/about.ts"
+    end
   end
 
   describe "transform/2 eager" do
@@ -60,6 +80,17 @@ defmodule DuskmoonBundler.JS.Transforms.GlobImportsTest do
 
       assert result =~ "./pages/home.ts"
       refute result =~ "./pages/about.ts"
+    end
+
+    test "preserves parent-relative paths and exclusions" do
+      source =
+        "const modules = import.meta.glob(['../glob_parent/*.ts', '!../glob_parent/about.ts'], { eager: true })"
+
+      result = DuskmoonBundler.JS.Transforms.GlobImports.transform(source, @fixture_dir)
+
+      assert result =~ ~S(from "../glob_parent/home.ts")
+      assert result =~ ~S("../glob_parent/home.ts":)
+      refute result =~ "glob_parent/about.ts"
     end
 
     test "supports eager named imports" do


### PR DESCRIPTION
## Summary
- normalize `import.meta.glob` patterns before resolving filesystem matches
- preserve true parent-relative module specifiers and object keys
- cover lazy and eager positive/negative parent-directory patterns

## Validation
- `MIX_ENV=test mix test test/duskmoon_bundler/js/transforms/glob_imports_test.exs`
- `MIX_ENV=test mix test` (from `apps/duskmoon_bundler`: 2 doctests, 450 tests)
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`

Fixes #144