### PR TITLE
fix: make button confirmations accessible modals

### DIFF
--- a/apps/duskmoon_bundler/test/support/cdp_browser.exs
+++ b/apps/duskmoon_bundler/test/support/cdp_browser.exs
@@ -42,6 +42,10 @@ defmodule DuskmoonBundler.Integration.CDPBrowser do
     GenServer.call(browser, {:evaluate, page, expression, opts}, call_timeout(opts))
   end
 
+  def command(%Page{browser: browser} = page, method, params \\ %{}, opts \\ []) do
+    GenServer.call(browser, {:command, page, method, params, opts}, call_timeout(opts))
+  end
+
   @impl true
   def init(opts) do
     with {:ok, executable} <- chromium_executable(opts),
@@ -147,6 +151,15 @@ defmodule DuskmoonBundler.Integration.CDPBrowser do
 
       {:error, reason, state} ->
         {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:command, %Page{} = page, method, params, opts}, _from, state) do
+    timeout = timeout(opts)
+
+    case cdp_call(state, method, params, page.session_id, timeout) do
+      {:ok, result, state} -> {:reply, {:ok, result}, state}
+      {:error, reason, state} -> {:reply, {:error, reason}, state}
     end
   end
 

--- a/apps/duskmoon_storybook/storybook/action/button.story.exs
+++ b/apps/duskmoon_storybook/storybook/action/button.story.exs
@@ -5,7 +5,7 @@ defmodule Storybook.Action.Button do
 
   def description,
     do:
-      "Button component wrapping el-dm-button with color/style variants, sizes, shapes, loading/disabled states, prefix/suffix slots, confirm popover, and noise effect."
+      "Button component wrapping el-dm-button with color/style variants, sizes, shapes, loading/disabled states, prefix/suffix slots, confirm modal, and noise effect."
 
   def variations do
     [
@@ -123,7 +123,7 @@ defmodule Storybook.Action.Button do
       # ── Confirm Dialog ────────────────────────────────────────────────
       %VariationGroup{
         id: :confirm,
-        description: "Confirm popover variants",
+        description: "Confirm modal variants",
         variations: [
           %Variation{
             id: :remove,
@@ -157,7 +157,7 @@ defmodule Storybook.Action.Button do
       # ── Confirm Dialog Customization ───────────────────────────────
       %VariationGroup{
         id: :confirm_customization,
-        description: "Confirm popover with custom button text, classes, and no-cancel option",
+        description: "Confirm modal with custom button text, classes, and no-cancel option",
         variations: [
           %Variation{
             id: :custom_button_text,
@@ -172,7 +172,7 @@ defmodule Storybook.Action.Button do
           },
           %Variation{
             id: :no_cancel_button,
-            description: "Confirm popover without cancel button",
+            description: "Confirm modal without cancel button",
             attributes: %{
               variant: "success",
               confirm: "Your changes have been saved.",
@@ -183,7 +183,7 @@ defmodule Storybook.Action.Button do
           },
           %Variation{
             id: :custom_dialog_label,
-            description: "Confirm popover with custom accessible label",
+            description: "Confirm modal with custom accessible label",
             attributes: %{
               variant: "primary",
               confirm: "Do you want to publish this post?",

--- a/apps/phoenix_duskmoon/assets/js/phoenix_duskmoon.js
+++ b/apps/phoenix_duskmoon/assets/js/phoenix_duskmoon.js
@@ -14,6 +14,9 @@ const DM_EVENTS = [
 const COPY_SELECTOR = "[data-copy-value]";
 const COPY_FEEDBACK_DURATION = 2000;
 const COPY_LISTENER = Symbol.for("phoenix-duskmoon.copy-listener");
+const DIALOG_SELECTOR = 'dialog[data-dm-confirm-dialog="true"]';
+const DIALOG_CONFIRM_SELECTOR = '[data-dm-confirm-action="true"]';
+const DIALOG_BEHAVIOR_LISTENERS = Symbol.for("phoenix-duskmoon.dialog-behavior-listeners");
 const copyFeedback = new WeakMap();
 
 /**
@@ -359,7 +362,25 @@ export function installClipboardBehavior(root = globalThis.document, options = {
   root[COPY_LISTENER] = listener;
 }
 
+/** Close the current confirm dialog before submit/reset/custom command default actions. */
+export function handleDialogConfirmClick(event) {
+  const path = event.composedPath?.() ?? [];
+  const action = path.find((node) => node.matches?.(DIALOG_CONFIRM_SELECTOR));
+  const dialog = path.find((node) => node.matches?.(DIALOG_SELECTOR));
+
+  if (action && dialog?.open) dialog.close();
+}
+
+/** Install CSP-safe delegated behavior for LiveView-patched confirm dialogs. */
+export function installDialogBehavior(root = globalThis.document) {
+  if (!root?.addEventListener || root[DIALOG_BEHAVIOR_LISTENERS]) return;
+
+  root.addEventListener("click", handleDialogConfirmClick, true);
+  root[DIALOG_BEHAVIOR_LISTENERS] = handleDialogConfirmClick;
+}
+
 installClipboardBehavior();
+installDialogBehavior();
 
 // Export to window for non-module usage
 if (typeof window !== "undefined") {

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
@@ -4,7 +4,7 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
 
   Provides three button modes:
   - Standard button with variants and sizes
-  - Button with confirmation popover (Invoker Commands API)
+  - Button with confirmation modal (Invoker Commands API)
   - Noise effect button (decorative)
 
   When `command` / `commandfor` are set, renders a native `<button>` so the
@@ -24,6 +24,8 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
 
   """
   use Phoenix.Component
+
+  import PhoenixDuskmoon.Component.Feedback.Dialog, only: [dm_modal: 1]
 
   # The el-dm-button custom element only supports: primary, secondary, tertiary,
   # ghost, outline. For other variants (info, success, warning, error, accent, link)
@@ -50,7 +52,6 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
                     "}"
                   ]
                   |> Enum.join(" ")
-
   defp map_variant(nil), do: nil
   defp map_variant(v) when is_map_key(@variant_map, v), do: @variant_map[v]
   defp map_variant(v) when v in @color_override_variants, do: "primary"
@@ -137,18 +138,18 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   attr(:noise, :boolean, default: false, doc: "Use noise effect button style")
   attr(:content, :string, default: "", doc: "Content text for noise button")
 
-  # Confirm popover attributes
-  attr(:confirm, :string, default: "", doc: "Confirmation message (enables confirm popover)")
-  attr(:confirm_title, :string, default: "", doc: "Title for confirmation popover")
-  attr(:confirm_text, :string, default: "Yes", doc: "Text for the confirm button in popover")
-  attr(:cancel_text, :string, default: "Cancel", doc: "Text for the cancel button in popover")
+  # Confirm modal attributes
+  attr(:confirm, :string, default: "", doc: "Confirmation message (enables confirm modal)")
+  attr(:confirm_title, :string, default: "", doc: "Title for confirmation modal")
+  attr(:confirm_text, :string, default: "Yes", doc: "Text for the confirm button in modal")
+  attr(:cancel_text, :string, default: "Cancel", doc: "Text for the cancel button in modal")
   attr(:confirm_class, :any, default: nil, doc: "CSS class for confirm button")
   attr(:cancel_class, :any, default: nil, doc: "CSS class for cancel button")
-  attr(:show_cancel_action, :boolean, default: true, doc: "Show cancel button in popover")
+  attr(:show_cancel_action, :boolean, default: true, doc: "Show cancel button in modal")
 
   attr(:confirm_label, :string,
     default: "Confirmation",
-    doc: "Accessible fallback label for confirm popover when no title is set (i18n)"
+    doc: "Accessible fallback label for confirm modal when no title is set (i18n)"
   )
 
   attr(:rest, :global,
@@ -180,64 +181,57 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   @spec dm_btn(map()) :: Phoenix.LiveView.Rendered.t()
   def dm_btn(%{confirm: confirm} = assigns) when confirm != "" do
     id = assigns.id || "btn-#{System.unique_integer([:positive])}"
-    popover_id = "confirm-popover-#{id}"
-    anchor_name = "--anchor-#{popover_id}"
+    dialog_id = "confirm-dialog-#{id}"
 
     assigns =
       assigns
       |> assign(:id, id)
-      |> assign(:popover_id, popover_id)
-      |> assign(:anchor_name, anchor_name)
-      |> assign(:confirm_rest, Map.put_new(assigns.rest, "type", "button"))
+      |> assign(:dialog_id, dialog_id)
+      |> assign(:confirm_rest, confirm_rest(assigns.rest, dialog_id))
       |> assign_button_style()
       |> then(fn assigns ->
         assigns
         |> assign(:button_class, btn_class_list(assigns))
-        |> assign(
-          :trigger_style,
-          merge_styles(assigns.el_style, "anchor-name: #{anchor_name}")
-        )
+        |> assign(:trigger_style, assigns.el_style)
       end)
 
     ~H"""
-    <button
-      type="button"
-      id={@id}
-      class={@button_class}
-      style={@trigger_style}
-      command="show-popover"
-      commandfor={@popover_id}
-      disabled={@disabled || @loading}
-      aria-disabled={(@disabled || @loading) && "true"}
-      aria-busy={@loading && "true"}
-      aria-haspopup="dialog"
-      aria-expanded="false"
-      aria-controls={@popover_id}
+    <.dm_modal
+      id={@dialog_id}
+      hide_close
+      size="sm"
+      dialog_label={@confirm_label}
+      autofocus={!@show_cancel_action}
+      tabindex="-1"
+      data-dm-confirm-dialog="true"
     >
-      <span :for={prefix <- @prefix} class="inline-flex items-center">{render_slot(prefix)}</span>
-      {render_slot(@inner_block)}
-      <span :for={suffix <- @suffix} class="inline-flex items-center">{render_slot(suffix)}</span>
-    </button>
-    <div
-      id={@popover_id}
-      popover
-      class="popover popover-bottom"
-      style={"position-anchor: #{@anchor_name}"}
-      role="dialog"
-      aria-labelledby={@confirm_title != "" && "#{@popover_id}-title"}
-      aria-label={@confirm_title == "" && @confirm_label}
-      ontoggle="this.classList.toggle('popover-show', this.matches(':popover-open')); var b=this.previousElementSibling; if(b) b.setAttribute('aria-expanded', this.matches(':popover-open'))"
-    >
-      <p :if={@confirm_title != ""} id={"#{@popover_id}-title"} class="font-semibold mb-1">
-        {@confirm_title}
-      </p>
-      <p>{@confirm}</p>
-      <div class="flex justify-end gap-2 mt-3">
+      <:trigger :let={modal_id}>
+        <button
+          type="button"
+          id={@id}
+          class={@button_class}
+          style={@trigger_style}
+          command="show-modal"
+          commandfor={modal_id}
+          disabled={@disabled || @loading}
+          aria-disabled={(@disabled || @loading) && "true"}
+          aria-busy={@loading && "true"}
+          aria-haspopup="dialog"
+          aria-controls={modal_id}
+        >
+          <span :for={prefix <- @prefix} class="inline-flex items-center">{render_slot(prefix)}</span>
+          {render_slot(@inner_block)}
+          <span :for={suffix <- @suffix} class="inline-flex items-center">{render_slot(suffix)}</span>
+        </button>
+      </:trigger>
+      <:title :if={@confirm_title != ""}>{@confirm_title}</:title>
+      <:body><p>{@confirm}</p></:body>
+      <:footer>
         {render_slot(@confirm_action)}
         <button
           :if={@confirm_action == []}
-          type="button"
           class={["btn", "btn-primary", @confirm_class]}
+          data-dm-confirm-action="true"
           {@confirm_rest}
         >
           {@confirm_text}
@@ -246,13 +240,14 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
           :if={@show_cancel_action}
           type="button"
           class={["btn", "btn-ghost", @cancel_class]}
-          command="hide-popover"
-          commandfor={@popover_id}
+          autofocus
+          command="close"
+          commandfor={@dialog_id}
         >
           {@cancel_text}
         </button>
-      </div>
-    </div>
+      </:footer>
+    </.dm_modal>
     """
   end
 
@@ -303,6 +298,28 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
     """
   end
 
+  defp confirm_rest(rest, dialog_id) do
+    rest = put_new_rest_attr(rest, :type, "type", "button")
+
+    if has_rest_attr?(rest, :command, "command") ||
+         has_rest_attr?(rest, :commandfor, "commandfor") do
+      rest
+    else
+      rest
+      |> Map.put("command", "close")
+      |> Map.put("commandfor", dialog_id)
+    end
+  end
+
+  defp put_new_rest_attr(rest, atom_key, string_key, value) do
+    if has_rest_attr?(rest, atom_key, string_key),
+      do: rest,
+      else: Map.put(rest, string_key, value)
+  end
+
+  defp has_rest_attr?(rest, atom_key, string_key),
+    do: Map.has_key?(rest, atom_key) || Map.has_key?(rest, string_key)
+
   defp assign_button_style(assigns) do
     assigns
     |> assign_new(:id, fn -> nil end)
@@ -350,10 +367,6 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   defp has_command?(rest) do
     Map.has_key?(rest, "command") || Map.has_key?(rest, :command)
   end
-
-  defp merge_styles(nil, other), do: other
-  defp merge_styles("", other), do: other
-  defp merge_styles(first, second), do: "#{first}; #{second}"
 
   attr(:id, :any, default: nil)
   attr(:el_variant, :string, default: nil)

--- a/apps/phoenix_duskmoon/mix.exs
+++ b/apps/phoenix_duskmoon/mix.exs
@@ -155,6 +155,8 @@ defmodule PhoenixDuskmoon.Mixfile do
       {:mdex_mermaid, "~> 0.3.6"},
       {:plug, "~> 1.19", optional: true},
       {:jason, "~> 1.4"},
+      {:mint, "~> 1.9", only: :test},
+      {:mint_web_socket, "~> 1.0", only: :test},
       {:ex_doc, ">= 0.0.0", runtime: false}
     ]
   end

--- a/apps/phoenix_duskmoon/test/js/phoenix_duskmoon.test.js
+++ b/apps/phoenix_duskmoon/test/js/phoenix_duskmoon.test.js
@@ -3,6 +3,7 @@ import { describe, expect, mock, test } from "bun:test";
 import {
 	copyTextToClipboard,
 	installClipboardBehavior,
+	installDialogBehavior,
 } from "../../assets/js/phoenix_duskmoon.js";
 
 function copyControl(value) {
@@ -114,5 +115,21 @@ describe("delegated clipboard behavior", () => {
 
 		expect(writeText).toHaveBeenCalledWith("protected value");
 		expect(document.execCommand).not.toHaveBeenCalled();
+	});
+});
+
+describe("delegated dialog behavior", () => {
+	test("installs one capturing confirm listener", () => {
+		const root = delegatedRoot();
+
+		installDialogBehavior(root);
+		installDialogBehavior(root);
+
+		expect(root.addEventListener).toHaveBeenCalledTimes(1);
+		expect(root.addEventListener).toHaveBeenCalledWith(
+			"click",
+			expect.any(Function),
+			true,
+		);
 	});
 });

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_browser_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_browser_test.exs
@@ -1,0 +1,197 @@
+defmodule PhoenixDuskmoon.Component.Action.ButtonBrowserTest do
+  use ExUnit.Case, async: false
+
+  import Phoenix.LiveViewTest
+  import PhoenixDuskmoon.Component.Action.Button
+
+  alias DuskmoonBundler.Integration.CDPBrowser
+
+  @moduletag :integration
+
+  setup_all do
+    {:ok, browser} = CDPBrowser.start_link()
+    on_exit(fn -> CDPBrowser.stop(browser) end)
+    %{browser: browser}
+  end
+
+  setup %{browser: browser} do
+    {:ok, page} = CDPBrowser.new_page(browser)
+    on_exit(fn -> CDPBrowser.close_page(page) end)
+    %{page: page}
+  end
+
+  test "confirm modal traps focus and only confirm dispatches the action", %{page: page} do
+    component =
+      render_component(&dm_btn/1, %{
+        id: "remove",
+        confirm: "Remove?",
+        "phx-click": "remove",
+        type: "submit",
+        form: "remove-form",
+        inner_block: %{inner_block: fn _, _ -> "Remove" end}
+      })
+
+    runtime = File.read!(Path.expand("../../../../assets/js/phoenix_duskmoon.js", __DIR__))
+
+    html =
+      "<!doctype html><html lang=\"en\"><body><form id=\"remove-form\"></form><button id=\"outside\">Outside</button>#{component}<script type=\"module\">#{runtime}</script></body></html>"
+
+    url = "data:text/html;base64," <> Base.encode64(html)
+
+    :ok = CDPBrowser.goto(page, url)
+
+    {:ok, initial_state} =
+      CDPBrowser.evaluate(page, """
+      (() => {
+        const trigger = document.getElementById("remove")
+        const dialog = document.getElementById("confirm-dialog-remove")
+        const outside = document.getElementById("outside")
+        const cancel = dialog.querySelector(".btn-ghost")
+        const form = document.getElementById("remove-form")
+
+        window.destructiveCount = 0
+        window.submitCount = 0
+        document.addEventListener("click", (event) => {
+          const action = event.composedPath().find(
+            (node) => node.getAttribute?.("phx-click") === "remove"
+          )
+          if (action) window.destructiveCount++
+        })
+        form.addEventListener("submit", (event) => {
+          event.preventDefault()
+          window.submitCount++
+        })
+
+        trigger.focus()
+        trigger.click()
+        outside.focus()
+
+        return {
+          openedModally: dialog.open && dialog.matches(":modal"),
+          initialFocusOnCancel: document.activeElement === cancel,
+          outsideFocusBlocked: document.activeElement === cancel
+        }
+      })()
+      """)
+
+    assert initial_state == %{
+             "openedModally" => true,
+             "initialFocusOnCancel" => true,
+             "outsideFocusBlocked" => true
+           }
+
+    {:ok, %{"nodes" => nodes}} =
+      CDPBrowser.command(page, "Accessibility.getFullAXTree", %{}, timeout: 5_000)
+
+    dialog_nodes =
+      Enum.filter(nodes, fn node ->
+        node["ignored"] != true && get_in(node, ["role", "value"]) == "dialog"
+      end)
+
+    assert [%{"name" => %{"value" => "Confirmation"}}] = dialog_nodes
+
+    :ok = dispatch_key(page, "Tab", "Tab", 9, 8)
+
+    assert {:ok, true} =
+             CDPBrowser.evaluate(
+               page,
+               "document.activeElement === document.querySelector('#confirm-dialog-remove .btn-primary')"
+             )
+
+    :ok = dispatch_key(page, "Tab", "Tab", 9)
+
+    assert {:ok, true} =
+             CDPBrowser.evaluate(
+               page,
+               "document.activeElement === document.querySelector('#confirm-dialog-remove .btn-ghost')"
+             )
+
+    :ok = dispatch_key(page, "Tab", "Tab", 9)
+
+    assert {:ok, true} =
+             CDPBrowser.evaluate(page, """
+             document.getElementById("confirm-dialog-remove").open &&
+               document.activeElement !== document.getElementById("outside")
+             """)
+
+    :ok = dispatch_key(page, "Escape", "Escape", 27)
+
+    assert {:ok,
+            %{
+              "closed" => true,
+              "focusReturned" => true,
+              "destructiveCount" => 0,
+              "submitCount" => 0
+            }} =
+             CDPBrowser.evaluate(page, """
+             (() => ({
+               closed: !document.getElementById("confirm-dialog-remove").open,
+               focusReturned: document.activeElement === document.getElementById("remove"),
+               destructiveCount: window.destructiveCount,
+               submitCount: window.submitCount
+             }))()
+             """)
+
+    assert {:ok,
+            %{
+              "closed" => true,
+              "focusReturned" => true,
+              "destructiveCount" => 0,
+              "submitCount" => 0
+            }} =
+             CDPBrowser.evaluate(page, """
+             (() => {
+               const trigger = document.getElementById("remove")
+               const dialog = document.getElementById("confirm-dialog-remove")
+               trigger.focus()
+               trigger.click()
+               dialog.querySelector(".btn-ghost").click()
+               return {
+                 closed: !dialog.open,
+                 focusReturned: document.activeElement === trigger,
+                 destructiveCount: window.destructiveCount,
+                 submitCount: window.submitCount
+               }
+             })()
+             """)
+
+    assert {:ok,
+            %{
+              "closed" => true,
+              "focusReturned" => true,
+              "destructiveCount" => 1,
+              "submitCount" => 1
+            }} =
+             CDPBrowser.evaluate(page, """
+             (() => {
+               const trigger = document.getElementById("remove")
+               const dialog = document.getElementById("confirm-dialog-remove")
+               trigger.focus()
+               trigger.click()
+               dialog.querySelector(".btn-primary").click()
+               return {
+                 closed: !dialog.open,
+                 focusReturned: document.activeElement === trigger,
+                 destructiveCount: window.destructiveCount,
+                 submitCount: window.submitCount
+               }
+             })()
+             """)
+  end
+
+  defp dispatch_key(page, key, code, key_code, modifiers \\ 0) do
+    params = %{
+      "key" => key,
+      "code" => code,
+      "windowsVirtualKeyCode" => key_code,
+      "modifiers" => modifiers
+    }
+
+    with {:ok, _result} <-
+           CDPBrowser.command(page, "Input.dispatchKeyEvent", Map.put(params, "type", "keyDown")),
+         {:ok, _result} <-
+           CDPBrowser.command(page, "Input.dispatchKeyEvent", Map.put(params, "type", "keyUp")) do
+      :ok
+    end
+  end
+end

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
@@ -245,7 +245,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ "Submit form"
   end
 
-  test "renders button with confirmation popover" do
+  test "renders button with confirmation modal" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
@@ -253,30 +253,48 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
       })
 
     assert result =~ ~s[<button]
-    assert result =~ ~s[command="show-popover"]
-    assert result =~ ~s[commandfor="confirm-popover-]
-    assert result =~ ~s[id="confirm-popover-]
-    assert result =~ ~s[popover]
-    assert result =~ "popover-bottom"
+    assert result =~ ~s[command="show-modal"]
+    assert result =~ ~s[commandfor="confirm-dialog-]
+    assert result =~ ~s[<dialog id="confirm-dialog-]
+    assert result =~ "dialog-sm"
     refute result =~ "el-dm-dialog"
-    refute result =~ "confirm-dialog"
     assert result =~ ~s[Are you sure?]
     assert result =~ ~s[Yes]
-    assert result =~ ~s[command="hide-popover"]
+    assert result =~ ~s[command="close"]
     assert result =~ ~s[Cancel]
   end
 
-  test "renders confirm popover with role dialog" do
+  test "renders confirmation as a native modal with safe focus management" do
+    result =
+      render_component(&dm_btn/1, %{
+        id: "remove",
+        confirm: "Remove?",
+        "phx-click": "remove",
+        inner_block: %{inner_block: fn _, _ -> "Remove" end}
+      })
+
+    assert result =~ ~s[command="show-modal"]
+    assert result =~ ~s[<dialog id="confirm-dialog-remove"]
+    assert result =~ ~s[autofocus]
+    assert result =~ ~s[data-dm-confirm-dialog="true"]
+    assert length(String.split(result, ~s[command="close"])) - 1 == 2
+    assert length(String.split(result, ~s[phx-click="remove"])) - 1 == 1
+    refute result =~ ~s[popover]
+    refute result =~ ~s[role="dialog"]
+  end
+
+  test "renders confirm modal with one implicit dialog role" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
         inner_block: %{inner_block: fn _, _ -> "Delete" end}
       })
 
-    assert result =~ ~s[role="dialog"]
+    assert result =~ ~s[<dialog]
+    refute result =~ ~s[role="dialog"]
   end
 
-  test "confirm popover has aria-label fallback when no title" do
+  test "confirm modal has aria-label fallback when no title" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
@@ -286,7 +304,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ ~s[aria-label="Confirmation"]
   end
 
-  test "confirm popover has aria-labelledby when title is provided" do
+  test "confirm modal has aria-labelledby when title is provided" do
     result =
       render_component(&dm_btn/1, %{
         id: "del-btn",
@@ -295,11 +313,11 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
         inner_block: %{inner_block: fn _, _ -> "Delete" end}
       })
 
-    assert result =~ ~s[aria-labelledby="confirm-popover-del-btn-title"]
+    assert result =~ ~s[aria-labelledby="confirm-dialog-del-btn-title"]
     refute result =~ ~s[aria-label="Confirmation"]
   end
 
-  test "renders button with confirmation popover and custom title" do
+  test "renders button with confirmation modal and custom title" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
@@ -311,7 +329,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ ~s[Are you sure?]
   end
 
-  test "renders button with confirmation popover and custom classes" do
+  test "renders button with confirmation modal and custom classes" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
@@ -324,7 +342,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ "my-cancel-class"
   end
 
-  test "renders button with confirmation popover without cancel action" do
+  test "renders button with confirmation modal without cancel action" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
@@ -461,11 +479,11 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
       })
 
     assert result =~ ~s[id="del-btn"]
-    assert result =~ ~s[id="confirm-popover-del-btn"]
+    assert result =~ ~s[id="confirm-dialog-del-btn"]
     assert result =~ "Really delete?"
   end
 
-  test "renders button with confirm popover title only when title is non-empty" do
+  test "renders button with confirm modal title only when title is non-empty" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Sure?",
@@ -568,7 +586,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ "--color-primary: var(--color-error)"
   end
 
-  test "renders confirm popover Yes button passes rest attributes" do
+  test "renders confirm modal Yes button passes rest attributes" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
@@ -579,6 +597,20 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ ~s[phx-click="delete"]
   end
 
+  test "confirm modal preserves a custom confirm command target" do
+    result =
+      render_component(&dm_btn/1, %{
+        confirm: "Continue?",
+        command: "show-modal",
+        commandfor: "next-dialog",
+        inner_block: %{inner_block: fn _, _ -> "Continue" end}
+      })
+
+    assert result =~ ~s[data-dm-confirm-action="true"]
+    assert result =~ ~s[command="show-modal"]
+    assert result =~ ~s[commandfor="next-dialog"]
+  end
+
   test "renders button without confirm when confirm is empty string" do
     result =
       render_component(&dm_btn/1, %{
@@ -587,7 +619,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
       })
 
     refute result =~ "el-dm-dialog"
-    refute result =~ "confirm-popover"
+    refute result =~ "confirm-dialog"
     assert result =~ "Normal Button"
   end
 
@@ -660,7 +692,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ "requestSubmit(submitter)"
   end
 
-  test "renders confirm popover with empty confirm_action shows default Yes button" do
+  test "renders confirm modal with empty confirm_action shows default Yes button" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Are you sure?",
@@ -673,7 +705,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ "Cancel"
   end
 
-  test "renders confirm popover with custom confirm_text" do
+  test "renders confirm modal with custom confirm_text" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Delete this?",
@@ -685,7 +717,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     refute result =~ ">Yes<"
   end
 
-  test "renders confirm popover with custom cancel_text" do
+  test "renders confirm modal with custom cancel_text" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Delete this?",
@@ -696,7 +728,7 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ "No"
   end
 
-  test "renders confirm popover with custom confirm_text and cancel_text" do
+  test "renders confirm modal with custom confirm_text and cancel_text" do
     result =
       render_component(&dm_btn/1, %{
         confirm: "Really?",

--- a/apps/phoenix_duskmoon/test/test_helper.exs
+++ b/apps/phoenix_duskmoon/test/test_helper.exs
@@ -1,1 +1,3 @@
+Code.require_file("../../duskmoon_bundler/test/support/cdp_browser.exs", __DIR__)
+
 ExUnit.start()

--- a/skills/phoenix-duskmoon-ui/references/components.md
+++ b/skills/phoenix-duskmoon-ui/references/components.md
@@ -32,7 +32,7 @@ Three clauses: standard, confirm dialog, noise effect.
 | `disabled` | boolean | false | |
 | `noise` | boolean | false | Activates noise-effect button |
 | `content` | string | "" | Button text (for noise variant) |
-| `confirm` | string | "" | Confirmation message (activates confirm popover) |
+| `confirm` | string | "" | Confirmation message (activates confirm modal) |
 | `confirm_title` | string | "" | Popover title |
 | `confirm_text` | string | "Yes" | Confirm button text |
 | `cancel_text` | string | "Cancel" | Cancel button text |


### PR DESCRIPTION
## Summary
- render `dm_btn` confirmations through the native `dm_modal` component
- focus Cancel initially, keep the page inert, close on Escape/Cancel/Confirm, and restore trigger focus
- preserve submit/reset and custom command behavior with a CSP-safe delegated close listener
- add real-Chromium coverage for the accessibility tree, keyboard containment, dismissal, and single confirm dispatch

## Validation
- `MIX_ENV=test mix test` (from `apps/phoenix_duskmoon`: 3131 tests)
- `bun test test/js/phoenix_duskmoon.test.js` (5 tests)
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`

Fixes #142
Fixes #143