### PR TITLE
fix: add semantic navigation and removal to chips

### DIFF
--- a/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/chip.html.heex
+++ b/apps/duskmoon_storybook/lib/duskmoon_storybook_web/controllers/components/data_display_html/chip.html.heex
@@ -11,12 +11,14 @@
 
   <.dm_markdown content={"""
   ## Overview
-  Chip component for displaying tags, filters, or selections. Wraps `<el-dm-chip>` custom element.
+  Chip component for displaying tags, filters, or selections. Standard chips wrap the
+  `<el-dm-chip>` custom element; navigation and LiveView removal use native accessible controls.
 
   ## Usage
   ```elixir
   <.dm_chip color="primary">Tag</.dm_chip>
-  <.dm_chip color="error" deletable>Remove</.dm_chip>
+  <.dm_chip href="/categories/elixir" color="primary">Elixir</.dm_chip>
+  <.dm_chip deletable delete_event="remove-category" delete_label="Remove category">Remove</.dm_chip>
   <.dm_chip color="success" selected>Active</.dm_chip>
   ```
   """} />
@@ -51,5 +53,23 @@
     <.dm_chip color="error" deletable>Deletable</.dm_chip>
     <.dm_chip color="success" selected>Selected</.dm_chip>
     <.dm_chip color="info" disabled>Disabled</.dm_chip>
+  </div>
+
+  <h3 class="text-xl font-semibold mt-8 mb-4">Semantic Navigation and Removal</h3>
+  <div class="flex flex-wrap gap-2">
+    <.dm_chip href={~p"/components/data-display/chip"} color="primary">
+      Chip documentation
+    </.dm_chip>
+    <.dm_chip
+      deletable
+      delete_event="remove-chip"
+      delete_label="Remove category"
+      color="error"
+    >
+      Removable
+    </.dm_chip>
+    <.dm_chip href={~p"/components/data-display/chip"} disabled>
+      Disabled link
+    </.dm_chip>
   </div>
 </.dm_card>

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/chip.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/chip.ex
@@ -2,7 +2,8 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Chip do
   @moduledoc """
   Chip component for displaying tags, filters, or selections.
 
-  Wraps the `<el-dm-chip>` custom element.
+  Wraps the `<el-dm-chip>` custom element for standard chips and provides
+  native link and LiveView removal modes with accessible semantics.
 
   ## Examples
 
@@ -14,6 +15,12 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Chip do
 
       <.dm_chip color="success" selected>Active</.dm_chip>
 
+      <.dm_chip href="/categories/elixir" color="primary">Elixir</.dm_chip>
+
+      <.dm_chip deletable delete_event="remove-category" delete_label="Remove category">
+        Elixir
+      </.dm_chip>
+
   ## Attributes
 
   * `variant` - Chip variant: filled, outlined, soft (default: filled)
@@ -22,7 +29,13 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Chip do
   * `deletable` - Whether the chip shows a delete button (default: false)
   * `selected` - Whether the chip is in selected state (default: false)
   * `disabled` - Whether the chip is disabled (default: false)
+  * `href`, `navigate`, `patch` - Render the chip as a semantic link
+  * `delete_event` - Render a native removal button when used with `deletable`
+  * `delete_label` - Accessible name for the removal button
   * `class` - Additional CSS classes
+
+  Navigation and native removal are separate modes. When both are configured,
+  `deletable` with `delete_event` takes precedence.
 
   ## Slots
 
@@ -39,6 +52,8 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Chip do
 
       <.dm_chip color="info">Tag</.dm_chip>
       <.dm_chip color="warning" variant="outlined" deletable>Filter</.dm_chip>
+      <.dm_chip navigate="/tags/elixir">Elixir</.dm_chip>
+      <.dm_chip deletable delete_event="remove-tag" delete_label="Remove Elixir">Elixir</.dm_chip>
   """
   @doc type: :component
   attr(:id, :any, default: nil, doc: "HTML id attribute")
@@ -60,14 +75,105 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Chip do
   attr(:deletable, :boolean, default: false, doc: "show a delete button on the chip")
   attr(:selected, :boolean, default: false, doc: "mark the chip as selected")
   attr(:disabled, :boolean, default: false, doc: "disable the chip")
-  attr(:rest, :global)
+
+  attr(:navigate, :string,
+    default: nil,
+    doc: "navigate to another LiveView when the chip is activated"
+  )
+
+  attr(:patch, :string,
+    default: nil,
+    doc: "patch the current LiveView when the chip is activated"
+  )
+
+  attr(:href, :any,
+    default: nil,
+    doc: "use traditional browser navigation when the chip is activated"
+  )
+
+  attr(:replace, :boolean,
+    default: false,
+    doc: "replace browser history when using navigate or patch"
+  )
+
+  attr(:delete_event, :any,
+    default: nil,
+    doc: "LiveView event name or JS command dispatched by the native removal button"
+  )
+
+  attr(:delete_label, :string,
+    default: "Remove chip",
+    doc: "accessible label for the native removal button"
+  )
+
+  attr(:rest, :global,
+    include: ~w(download hreflang referrerpolicy rel target type),
+    doc: "additional HTML attributes"
+  )
 
   slot(:inner_block, required: true, doc: "chip label text")
   slot(:icon, doc: "leading icon content")
 
+  # WORKAROUND(upstream): duskmoon-dev/duskmoon-elements#74
+  # Native modes avoid nested links and inaccessible delete controls until the
+  # custom element provides equivalent semantic APIs.
   def dm_chip(assigns) do
+    mode = chip_mode(assigns)
+    {rest, delete_rest} = split_delete_rest(mode, assigns.rest)
+
+    assigns =
+      assigns
+      |> assign(:mode, mode)
+      |> assign(:chip_class, chip_class(assigns))
+      |> assign(:rest, rest)
+      |> assign(:delete_rest, delete_rest)
+
     ~H"""
+    <.link
+      :if={@mode == :link && !@disabled}
+      id={@id}
+      navigate={@navigate}
+      patch={@patch}
+      href={@href}
+      replace={@replace}
+      class={@chip_class}
+      {@rest}
+    >
+      <span :if={@icon != []} class="chip-icon">{render_slot(@icon)}</span>
+      <span class="chip-label">{render_slot(@inner_block)}</span>
+    </.link>
+    <span
+      :if={@mode == :link && @disabled}
+      id={@id}
+      class={@chip_class}
+      aria-disabled="true"
+      {@rest}
+    >
+      <span :if={@icon != []} class="chip-icon">{render_slot(@icon)}</span>
+      <span class="chip-label">{render_slot(@inner_block)}</span>
+    </span>
+    <span
+      :if={@mode == :delete}
+      id={@id}
+      class={@chip_class}
+      aria-disabled={@disabled && "true"}
+      {@rest}
+    >
+      <span :if={@icon != []} class="chip-icon">{render_slot(@icon)}</span>
+      <span class="chip-label">{render_slot(@inner_block)}</span>
+      <button
+        type="button"
+        class="chip-close"
+        phx-click={@delete_event}
+        disabled={@disabled}
+        aria-label={@delete_label}
+        {@delete_rest}
+      >
+        <span aria-hidden="true">×</span>
+      </button>
+    </span>
     <el-dm-chip
+      :if={@mode == :element}
       id={@id}
       variant={@variant}
       color={@color}
@@ -84,4 +190,48 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Chip do
     </el-dm-chip>
     """
   end
+
+  defp chip_mode(%{deletable: true, delete_event: delete_event}) when not is_nil(delete_event),
+    do: :delete
+
+  defp chip_mode(%{href: href, navigate: navigate, patch: patch})
+       when not is_nil(href) or not is_nil(navigate) or not is_nil(patch),
+       do: :link
+
+  defp chip_mode(_assigns), do: :element
+
+  defp split_delete_rest(:delete, rest) do
+    Enum.reduce(rest, {%{}, %{}}, fn {key, value}, {chip_rest, delete_rest} ->
+      if delete_button_attr?(to_string(key)) do
+        {chip_rest, Map.put(delete_rest, key, value)}
+      else
+        {Map.put(chip_rest, key, value), delete_rest}
+      end
+    end)
+  end
+
+  defp split_delete_rest(_mode, rest), do: {rest, %{}}
+
+  defp delete_button_attr?("phx-target"), do: true
+  defp delete_button_attr?("phx-disable-with"), do: true
+  defp delete_button_attr?("phx-page-loading"), do: true
+  defp delete_button_attr?("phx-value-" <> _name), do: true
+  defp delete_button_attr?(_attribute), do: false
+
+  defp chip_class(assigns) do
+    [
+      "chip",
+      chip_mode(assigns) == :link && "chip-clickable",
+      variant_class(assigns.variant),
+      assigns.color && "chip-#{assigns.color}",
+      assigns.size != "md" && "chip-#{assigns.size}",
+      assigns.selected && "chip-selected",
+      assigns.disabled && "chip-disabled",
+      assigns.class
+    ]
+  end
+
+  defp variant_class("outlined"), do: "chip-outlined"
+  defp variant_class("soft"), do: "chip-tonal"
+  defp variant_class(_variant), do: nil
 end

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/chip_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/chip_test.exs
@@ -294,4 +294,163 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.ChipTest do
     assert result =~ "my-chip"
     assert result =~ "Full"
   end
+
+  test "renders href navigation as one semantic link" do
+    result =
+      render_component(&dm_chip/1, %{
+        href: "/categories/elixir",
+        color: "primary",
+        target: "_blank",
+        rel: "noopener",
+        inner_block: inner_block("Elixir")
+      })
+
+    assert result =~ ~s[<a href="/categories/elixir"]
+    assert result =~ ~s[target="_blank"]
+    assert result =~ ~s[rel="noopener"]
+    assert result =~ "chip-clickable"
+    assert result =~ "chip-primary"
+    refute result =~ "el-dm-chip"
+    refute result =~ ~s[role="button"]
+  end
+
+  test "renders LiveView navigation with link semantics" do
+    result =
+      render_component(&dm_chip/1, %{
+        navigate: "/categories/phoenix",
+        inner_block: inner_block("Phoenix")
+      })
+
+    assert result =~ ~s[href="/categories/phoenix"]
+    assert result =~ ~s[data-phx-link="redirect"]
+    refute result =~ "el-dm-chip"
+  end
+
+  test "renders replaceable LiveView patch navigation with native classes" do
+    result =
+      render_component(&dm_chip/1, %{
+        patch: "/categories?page=2",
+        replace: true,
+        variant: "soft",
+        size: "sm",
+        selected: true,
+        class: "category-chip",
+        inner_block: inner_block("Page 2")
+      })
+
+    assert result =~ ~s[href="/categories?page=2"]
+    assert result =~ ~s[data-phx-link="patch"]
+    assert result =~ ~s[data-phx-link-state="replace"]
+    assert result =~ "chip-tonal"
+    assert result =~ "chip-sm"
+    assert result =~ "chip-selected"
+    assert result =~ "category-chip"
+  end
+
+  test "renders an accessible native removal callback" do
+    result =
+      render_component(&dm_chip/1, %{
+        deletable: true,
+        delete_event: "remove-category",
+        delete_label: "Remove Elixir category",
+        color: "error",
+        inner_block: inner_block("Elixir")
+      })
+
+    assert result =~ ~s[<span class="chip chip-error"]
+    assert result =~ ~s[<button type="button"]
+    assert result =~ ~s[class="chip-close"]
+    assert result =~ ~s[phx-click="remove-category"]
+    assert result =~ ~s[aria-label="Remove Elixir category"]
+    refute result =~ "el-dm-chip"
+    refute result =~ ~s[role="button"]
+  end
+
+  test "forwards LiveView delete target and values to the removal button" do
+    result =
+      render_component(&dm_chip/1, %{
+        deletable: true,
+        delete_event: "remove-category",
+        "phx-target": "#categories",
+        "phx-value-id": "42",
+        inner_block: inner_block("Elixir")
+      })
+
+    [_, button] = String.split(result, "<button", parts: 2)
+    [button_attrs, _] = String.split(button, ">", parts: 2)
+
+    assert button_attrs =~ ~s[phx-click="remove-category"]
+    assert button_attrs =~ ~s[phx-target="#categories"]
+    assert button_attrs =~ ~s[phx-value-id="42"]
+  end
+
+  test "accepts a LiveView JS delete command with values" do
+    result =
+      render_component(&dm_chip/1, %{
+        deletable: true,
+        delete_event: Phoenix.LiveView.JS.push("remove-category", value: %{id: 42}),
+        inner_block: inner_block("Elixir")
+      })
+
+    [_, button] = String.split(result, "<button", parts: 2)
+    [button_attrs, _] = String.split(button, ">", parts: 2)
+
+    assert button_attrs =~ "remove-category"
+    assert button_attrs =~ "&quot;id&quot;:42"
+  end
+
+  test "disables the native removal button with the chip" do
+    result =
+      render_component(&dm_chip/1, %{
+        deletable: true,
+        delete_event: "remove-category",
+        disabled: true,
+        inner_block: inner_block("Elixir")
+      })
+
+    assert result =~ ~s[aria-disabled="true"]
+
+    [_, button] = String.split(result, "<button", parts: 2)
+    [button_attrs, _] = String.split(button, ">", parts: 2)
+    assert button_attrs =~ "disabled"
+  end
+
+  test "keeps the custom element for legacy deletable chips without a callback" do
+    result =
+      render_component(&dm_chip/1, %{
+        deletable: true,
+        inner_block: inner_block("Legacy")
+      })
+
+    assert result =~ "<el-dm-chip"
+    assert result =~ "deletable"
+  end
+
+  test "native removal takes precedence over navigation" do
+    result =
+      render_component(&dm_chip/1, %{
+        href: "/categories/elixir",
+        deletable: true,
+        delete_event: "remove-category",
+        inner_block: inner_block("Elixir")
+      })
+
+    assert result =~ ~s[phx-click="remove-category"]
+    refute result =~ "<a "
+    refute result =~ "el-dm-chip"
+  end
+
+  test "renders disabled navigation as a noninteractive native chip" do
+    result =
+      render_component(&dm_chip/1, %{
+        href: "/categories/disabled",
+        disabled: true,
+        inner_block: inner_block("Disabled")
+      })
+
+    assert result =~ ~s[<span class="chip chip-clickable chip-disabled"]
+    assert result =~ ~s[aria-disabled="true"]
+    refute result =~ "<a "
+    refute result =~ "el-dm-chip"
+  end
 end

--- a/skills/phoenix-duskmoon-ui/references/components.md
+++ b/skills/phoenix-duskmoon-ui/references/components.md
@@ -274,6 +274,12 @@ Slots: `inner_block`, `name_slot`, `call`, `result`
 | `deletable` | boolean | false | |
 | `selected` | boolean | false | |
 | `disabled` | boolean | false | |
+| `href` | any | nil | Traditional link navigation |
+| `navigate` | string | nil | LiveView navigation |
+| `patch` | string | nil | LiveView patch navigation |
+| `replace` | boolean | false | Replace browser history for navigate/patch |
+| `delete_event` | any | nil | LiveView event or JS command for native removal mode |
+| `delete_label` | string | "Remove chip" | Accessible removal-button label |
 
 Slots: `inner_block` (required), `icon`
 


### PR DESCRIPTION
## Summary
- add native `href`, `navigate`, and `patch` chip link modes without nested interactive controls
- add an accessible native removal button with string or `Phoenix.LiveView.JS` callbacks
- forward LiveView targets and values to the actual delete button while preserving legacy custom-element chips
- document the temporary native workaround for duskmoon-dev/duskmoon-elements#74

## Validation
- `MIX_ENV=test mix test test/phoenix_duskmoon/component/data_display/chip_test.exs` (36 tests)
- `MIX_ENV=test mix test` (from `apps/phoenix_duskmoon`: 3138 tests)
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`
- Chromium accessibility tree and keyboard focus check

Fixes #141