### PR TITLE
fix: preserve modal open state across LiveView patches

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/feedback/dialog.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/feedback/dialog.ex
@@ -4,6 +4,7 @@ defmodule PhoenixDuskmoon.Component.Feedback.Dialog do
   `@duskmoon-dev/core` dialog CSS.
 
   Open and close with the Invoker Commands API (`command` / `commandfor`).
+  The client-owned `open` attribute is preserved across LiveView patches.
 
   ## Examples
 
@@ -20,6 +21,8 @@ defmodule PhoenixDuskmoon.Component.Feedback.Dialog do
 
   """
   use Phoenix.Component
+
+  alias Phoenix.LiveView.JS
 
   import PhoenixDuskmoon.Component.Icon.Icons
 
@@ -65,6 +68,11 @@ defmodule PhoenixDuskmoon.Component.Feedback.Dialog do
     doc: "Accessible fallback label when no title slot is provided (i18n)"
   )
 
+  attr(:"phx-mounted", JS,
+    default: %JS{},
+    doc: "additional LiveView JS commands composed before preserving the open attribute"
+  )
+
   attr(:rest, :global)
 
   slot(:trigger, doc: "Element that opens the modal") do
@@ -87,6 +95,7 @@ defmodule PhoenixDuskmoon.Component.Feedback.Dialog do
     assigns =
       assigns
       |> assign_new(:id, fn -> "modal-#{System.unique_integer([:positive])}" end)
+      |> assign(:mounted, preserve_open(assigns[:"phx-mounted"]))
 
     ~H"""
     {render_slot(@trigger, @id)}
@@ -95,6 +104,7 @@ defmodule PhoenixDuskmoon.Component.Feedback.Dialog do
       class={["dialog", dialog_size(@size), dialog_position(@position), @class]}
       aria-labelledby={@title != [] && "#{@id}-title"}
       aria-label={@title == [] && @dialog_label}
+      phx-mounted={@mounted}
       {@rest}
     >
       <div class="dialog-box">
@@ -133,6 +143,10 @@ defmodule PhoenixDuskmoon.Component.Feedback.Dialog do
     </dialog>
     """
   end
+
+  defp preserve_open(%JS{} = mounted), do: JS.concat(mounted, JS.ignore_attributes("open"))
+  defp preserve_open(false), do: JS.ignore_attributes("open")
+  defp preserve_open(nil), do: JS.ignore_attributes("open")
 
   defp dialog_size("sm"), do: "dialog-sm"
   defp dialog_size("lg"), do: "dialog-lg"

--- a/apps/phoenix_duskmoon/mix.exs
+++ b/apps/phoenix_duskmoon/mix.exs
@@ -149,7 +149,7 @@ defmodule PhoenixDuskmoon.Mixfile do
     [
       {:phoenix, "~> 1.8"},
       {:phoenix_html, "~> 4.0"},
-      {:phoenix_live_view, "~> 1.0"},
+      {:phoenix_live_view, "~> 1.1"},
       {:mdex, "~> 0.13.3"},
       {:mdex_gfm, "~> 0.2.0"},
       {:mdex_mermaid, "~> 0.3.6"},

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/feedback/dialog_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/feedback/dialog_test.exs
@@ -5,6 +5,8 @@ defmodule PhoenixDuskmoon.Component.Feedback.DialogTest do
   import Phoenix.LiveViewTest
   import PhoenixDuskmoon.Component.Feedback.Dialog
 
+  alias Phoenix.LiveView.JS
+
   defp body(text \\ "Content") do
     [%{inner_block: fn _, _ -> text end}]
   end
@@ -149,6 +151,45 @@ defmodule PhoenixDuskmoon.Component.Feedback.DialogTest do
       })
 
     assert result =~ "data-testid=\"confirm-dialog\""
+  end
+
+  test "preserves the client-owned open attribute across LiveView patches" do
+    result = render_component(&dm_modal/1, %{id: "persistent-dialog", body: body()})
+
+    assert result =~
+             ~s|phx-mounted="[[&quot;ignore_attrs&quot;,{&quot;attrs&quot;:[&quot;open&quot;]}]]"|
+
+    refute result =~ ~s[phx-update="ignore"]
+  end
+
+  test "composes open preservation with a caller phx-mounted command" do
+    result =
+      render_component(&dm_modal/1, %{
+        id: "composed-dialog",
+        body: body(),
+        "phx-mounted": JS.add_class("mounted")
+      })
+
+    assert length(String.split(result, ~s[phx-mounted=])) - 1 == 1
+    assert result =~ "add_class"
+    assert result =~ "ignore_attrs"
+    assert result =~ "&quot;open&quot;"
+
+    {add_class_index, _} = :binary.match(result, "add_class")
+    {ignore_attrs_index, _} = :binary.match(result, "ignore_attrs")
+    assert add_class_index < ignore_attrs_index
+  end
+
+  test "preserves open when a conditional phx-mounted command is false" do
+    result =
+      render_component(&dm_modal/1, %{
+        id: "conditional-dialog",
+        body: body(),
+        "phx-mounted": false
+      })
+
+    assert result =~
+             ~s|phx-mounted="[[&quot;ignore_attrs&quot;,{&quot;attrs&quot;:[&quot;open&quot;]}]]"|
   end
 
   test "renders modal with trigger slot" do


### PR DESCRIPTION
## Summary
- preserve the native dialog `open` attribute with `JS.ignore_attributes/1` while allowing modal contents to patch normally
- compose caller-provided `phx-mounted` JS commands into one ordered binding
- raise the Phoenix LiveView minimum to 1.1, where `ignore_attributes` was introduced
- cover default, composed, and conditional mount behavior

## Validation
- `MIX_ENV=test mix test test/phoenix_duskmoon/component/feedback/dialog_test.exs` (39 tests)
- `MIX_ENV=test mix test` (from `apps/phoenix_duskmoon`: 3145 tests)
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`
- `git diff --check`

Fixes #150