### PR TITLE
fix(bundler): preserve React App Clip async chunks

### DIFF
--- a/apps/duskmoon_bundler/CHANGELOG.md
+++ b/apps/duskmoon_bundler/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added `json_codec` as a runtime dependency.
 
 ### Fixed
+- React App Clip production builds now preserve lazy `import.meta.glob()` chunks while co-locating shared CommonJS require groups, keeping singleton packages such as React intact across entry and async chunks.
 - Production builds now fall back to a single bundle when code splitting would move a CommonJS dependency across chunks, preserving singleton packages such as React and preventing unresolved `react-dom/client` imports.
 - ESM code-split builds now rewrite Rolldown-normalized cross-chunk npm imports to emitted chunk URLs instead of leaving package specifiers in the output.
 - Generated installs now start `:duskmoon_bundler` in test, ensuring endpoints with code reloading enabled also start the DevServer cache and HMR supervision tree.

--- a/apps/duskmoon_bundler/guides/cheatsheets/configuration.cheatmd
+++ b/apps/duskmoon_bundler/guides/cheatsheets/configuration.cheatmd
@@ -69,7 +69,8 @@ JS downlevel target.
 config :duskmoon_bundler, format: :iife
 ```
 
-Output format: `:iife`, `:esm`, or `:cjs`.
+Standalone output format: `:iife`, `:esm`, or `:cjs`. Multi-file code-split
+output always uses ESM so chunks can import each other.
 
 ### Minify
 

--- a/apps/duskmoon_bundler/guides/features/code-splitting.md
+++ b/apps/duskmoon_bundler/guides/features/code-splitting.md
@@ -16,6 +16,9 @@ app-admin-c3d4e5f6.js  86 KB   (async)
 manifest.json           3 entries
 ```
 
+Multi-file code-split output uses ESM regardless of the standalone `format`
+setting because entry, common, and async chunks import each other.
+
 Shared modules between chunks are extracted into common chunks to avoid duplication. CSS imported by an async chunk is emitted beside that chunk, and CSS imported by shared chunks is tracked on the shared chunk.
 
 When a dynamic import has dependencies that would otherwise create a loading waterfall, DuskmoonBundler rewrites it through a small preload helper. The helper preloads imported JavaScript chunks and chunk-local CSS before executing the dynamic import.

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder.ex
@@ -48,6 +48,8 @@ defmodule DuskmoonBundler.Builder do
     * `:asset_url_prefix` — public URL prefix for emitted asset references (default: `"/assets"`)
     * `:code_splitting` — split dynamic imports into separate chunks (default: `true`)
     * `:tree_shaking` — remove unused exports (default: `true`)
+    * `:format` — standalone output format (`:iife`, `:esm`, or `:cjs`).
+      Multi-file code-split output always uses ESM so chunks can import each other.
     * `:chunks` — manual chunk definitions, map of chunk name to list of patterns:
 
           chunks: %{"vendor" => ["vue", "vue-router"], "ui" => ["assets/src/components"]}

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/builder/output.ex
@@ -70,6 +70,10 @@ defmodule DuskmoonBundler.Builder.Output do
 
     File.mkdir_p!(outdir)
 
+    # Cross-file chunks communicate through static imports and exports. Standalone
+    # builds may use IIFE or CommonJS, but split output must remain ESM.
+    bundle_opts = Keyword.put(bundle_opts, :format, :esm)
+
     graph =
       DuskmoonBundler.ChunkGraph.build(entry, modules, dep_map, manual_chunks: manual_chunks)
 
@@ -557,28 +561,36 @@ defmodule DuskmoonBundler.Builder.Output do
         {:cont, {:ok, acc}}
       else
         chunk_js = Rewriter.rewrite_external_imports(chunk_js, ctx)
-        chunk_js = add_chunk_facade(chunk_js, chunk_id, chunk)
-        {chunk_js, dynamic_import_placeholder} = Rewriter.protect_dynamic_imports(chunk_js)
 
-        external =
-          Rewriter.external_chunk_imports(
-            chunk_js,
-            chunk_import_map(chunk, graph, module_labels, dep_map)
-          )
+        facade_requirements =
+          chunk_export_requirements(chunk_id, graph, js_map, module_labels, dep_map)
 
-        bundle_opts =
-          bundle_opts
-          |> Keyword.put(:entry, chunk_entry_label(chunk_js))
-          |> put_external_imports(external)
+        with nil <- facade_requirements_error(chunk_id, chunk, facade_requirements) do
+          chunk_js = add_chunk_facade(chunk_js, chunk_id, chunk, facade_requirements)
+          {chunk_js, dynamic_import_placeholder} = Rewriter.protect_dynamic_imports(chunk_js)
 
-        case bundle_js_files(chunk_js, bundle_opts) do
-          {:ok, result} ->
-            {code, sourcemap} = extract_bundle_result(result)
-            code = Rewriter.restore_dynamic_imports(code, dynamic_import_placeholder)
-            {:cont, {:ok, Map.put(acc, chunk_id, {code, sourcemap})}}
+          external =
+            Rewriter.external_chunk_imports(
+              chunk_js,
+              chunk_import_map(chunk, graph, module_labels, dep_map)
+            )
 
-          {:error, errors} ->
-            {:halt, {:error, {:chunk_bundle_failed, chunk_id, errors}}}
+          bundle_opts =
+            bundle_opts
+            |> Keyword.put(:entry, chunk_entry_label(chunk_js))
+            |> put_external_imports(external)
+
+          case bundle_js_files(chunk_js, bundle_opts) do
+            {:ok, result} ->
+              {code, sourcemap} = extract_bundle_result(result)
+              code = Rewriter.restore_dynamic_imports(code, dynamic_import_placeholder)
+              {:cont, {:ok, Map.put(acc, chunk_id, {code, sourcemap})}}
+
+            {:error, errors} ->
+              {:halt, {:error, {:chunk_bundle_failed, chunk_id, errors}}}
+          end
+        else
+          reason -> {:halt, {:error, {:invalid_chunk_links, [reason]}}}
         end
       end
     end)
@@ -611,9 +623,12 @@ defmodule DuskmoonBundler.Builder.Output do
 
   defp chunk_entry_label([{label, _code} | _]), do: label
 
-  defp add_chunk_facade([_single] = js_files, _chunk_id, _chunk), do: js_files
+  defp add_chunk_facade([_single] = js_files, _chunk_id, %{type: type}, _requirements)
+       when type not in [:common, :manual],
+       do: js_files
 
-  defp add_chunk_facade(js_files, chunk_id, %{type: type}) when type in [:common, :manual] do
+  defp add_chunk_facade(js_files, chunk_id, %{type: type}, requirements)
+       when type in [:common, :manual] do
     {first_label, _code} = hd(js_files)
     facade_label = Path.join(Path.dirname(first_label), "__duskmoon_#{chunk_id}_entry__.js")
 
@@ -623,24 +638,161 @@ defmodule DuskmoonBundler.Builder.Output do
         "export * from #{Jason.encode!(specifier)};"
       end)
 
-    default_export =
-      Enum.find_value(js_files, fn {label, code} ->
-        if default_export?(code) do
-          "export { default } from #{Jason.encode!(module_specifier(facade_label, label))};\n"
-        end
-      end)
-
-    [{facade_label, (default_export || "") <> exports} | js_files]
+    required_exports = facade_required_exports(js_files, facade_label, requirements)
+    facade = exports <> "\n" <> required_exports
+    [{facade_label, facade} | js_files]
   end
 
-  defp add_chunk_facade(js_files, _chunk_id, _chunk), do: js_files
+  defp add_chunk_facade(js_files, _chunk_id, _chunk, _requirements), do: js_files
 
-  defp default_export?(code) do
-    case OXC.parse(code, "chunk.js") do
-      {:ok, ast} -> Enum.any?(ast.body, &(&1.type == :export_default_declaration))
-      {:error, _} -> false
+  defp facade_requirements_error(chunk_id, %{type: type}, requirements)
+       when type in [:common, :manual] do
+    default_labels =
+      for {label, names} <- requirements, MapSet.member?(names, :default), do: label
+
+    namespace_labels =
+      for {label, names} <- requirements, MapSet.member?(names, :namespace), do: label
+
+    cond do
+      length(default_labels) > 1 ->
+        {:ambiguous_default_exports, chunk_id, Enum.sort(default_labels)}
+
+      namespace_labels != [] ->
+        {:ambiguous_namespace_exports, chunk_id, Enum.sort(namespace_labels)}
+
+      true ->
+        nil
     end
   end
+
+  defp facade_requirements_error(_chunk_id, _chunk, _requirements), do: nil
+
+  defp facade_required_exports(js_files, facade_label, requirements) do
+    available_labels = MapSet.new(js_files, &elem(&1, 0))
+
+    requirements =
+      requirements
+      |> Enum.filter(fn {label, _names} -> MapSet.member?(available_labels, label) end)
+      |> Enum.sort_by(&elem(&1, 0))
+
+    name_counts =
+      requirements
+      |> Enum.flat_map(fn {_label, names} ->
+        names
+        |> Enum.reject(&(&1 in [:default, :namespace]))
+      end)
+      |> Enum.frequencies()
+
+    Enum.map_join(requirements, fn {label, names} ->
+      names =
+        names
+        |> Enum.reject(&(&1 == :namespace))
+        |> Enum.filter(fn
+          :default -> true
+          name -> Map.get(name_counts, name) == 1
+        end)
+        |> Enum.sort()
+
+      if names == [] do
+        ""
+      else
+        specifier = module_specifier(facade_label, label)
+        exports = Enum.map_join(names, ", ", &module_export_name/1)
+        "export { #{exports} } from #{Jason.encode!(specifier)};\n"
+      end
+    end)
+  end
+
+  defp module_export_name(:default), do: "default"
+
+  defp module_export_name(name) do
+    if String.match?(name, ~r/^[A-Za-z_$][A-Za-z0-9_$]*$/) do
+      name
+    else
+      Jason.encode!(name)
+    end
+  end
+
+  defp chunk_export_requirements(chunk_id, graph, js_map, module_labels, dep_map) do
+    Enum.reduce(dep_map, %{}, fn {importer, deps}, requirements ->
+      importer_chunk = Map.get(graph.module_to_chunk, importer)
+      importer_label = Map.get(module_labels, importer)
+      code = Map.get(js_map, importer_label)
+
+      if importer_chunk == chunk_id or not is_binary(importer_label) or not is_binary(code) do
+        requirements
+      else
+        deps
+        |> Map.get(:static, [])
+        |> Kernel.++(Map.get(deps, :dynamic, []))
+        |> Enum.uniq()
+        |> Enum.reduce(requirements, fn dependency, acc ->
+          if Map.get(graph.module_to_chunk, dependency) == chunk_id do
+            dependency_label = Map.get(module_labels, dependency)
+
+            if is_binary(dependency_label) do
+              specifier = "./" <> relative_label(importer_label, dependency_label)
+              names = import_requirements(code, specifier)
+
+              if MapSet.size(names) == 0 do
+                acc
+              else
+                Map.update(acc, dependency_label, names, &MapSet.union(&1, names))
+              end
+            else
+              acc
+            end
+          else
+            acc
+          end
+        end)
+      end
+    end)
+  end
+
+  defp import_requirements(code, specifier) do
+    case OXC.parse(code, "chunk.js") do
+      {:ok, ast} ->
+        Enum.reduce(ast.body, MapSet.new(), fn
+          %{type: :import_declaration, source: %{value: ^specifier}, specifiers: specifiers},
+          acc ->
+            Enum.reduce(specifiers, acc, &put_import_requirement/2)
+
+          %{
+            type: :export_named_declaration,
+            source: %{value: ^specifier},
+            specifiers: specifiers
+          },
+          acc ->
+            Enum.reduce(specifiers, acc, fn specifier, names ->
+              MapSet.put(names, normalize_import_requirement(ast_name(specifier.local)))
+            end)
+
+          %{type: :export_all_declaration, source: %{value: ^specifier}}, acc ->
+            MapSet.put(acc, :namespace)
+
+          _node, acc ->
+            acc
+        end)
+
+      {:error, _errors} ->
+        MapSet.new()
+    end
+  end
+
+  defp put_import_requirement(%{type: :import_default_specifier}, names),
+    do: MapSet.put(names, :default)
+
+  defp put_import_requirement(%{type: :import_specifier, imported: imported}, names),
+    do: MapSet.put(names, normalize_import_requirement(ast_name(imported)))
+
+  defp put_import_requirement(%{type: :import_namespace_specifier}, names),
+    do: MapSet.put(names, :namespace)
+
+  defp put_import_requirement(_specifier, names), do: names
+
+  defp normalize_import_requirement("default"), do: :default
+  defp normalize_import_requirement(name), do: name
 
   defp select_chunk_files(module_paths, js_map, module_labels) do
     module_paths

--- a/apps/duskmoon_bundler/lib/duskmoon_bundler/chunk_graph.ex
+++ b/apps/duskmoon_bundler/lib/duskmoon_bundler/chunk_graph.ex
@@ -75,7 +75,11 @@ defmodule DuskmoonBundler.ChunkGraph do
     shared =
       [entry_modules | Enum.map(async_chunks, &elem(&1, 2))]
       |> shared_modules()
-      |> Enum.reject(&MapSet.member?(dynamic_entry_set, &1))
+      |> MapSet.new()
+      |> MapSet.delete(entry_path)
+      |> expand_common_require_groups(dep_map, module_set, entry_path)
+      |> MapSet.difference(dynamic_entry_set)
+      |> MapSet.to_list()
 
     {entry_modules, common_chunk} =
       if shared == [] do
@@ -283,6 +287,37 @@ defmodule DuskmoonBundler.ChunkGraph do
     end)
     |> Enum.filter(fn {_module, count} -> count > 1 end)
     |> Enum.map(fn {module, _count} -> module end)
+  end
+
+  defp expand_common_require_groups(shared, dep_map, module_set, entry_path) do
+    expanded =
+      Enum.reduce(dep_map, shared, fn {module, deps}, acc ->
+        requires =
+          deps
+          |> Map.get(:requires, [])
+          |> Enum.filter(&MapSet.member?(module_set, &1))
+          |> Enum.reject(&(&1 == entry_path))
+
+        cond do
+          module == entry_path ->
+            acc
+
+          MapSet.member?(acc, module) ->
+            Enum.reduce(requires, acc, &MapSet.put(&2, &1))
+
+          Enum.any?(requires, &MapSet.member?(acc, &1)) and MapSet.member?(module_set, module) ->
+            MapSet.put(acc, module)
+
+          true ->
+            acc
+        end
+      end)
+
+    if MapSet.equal?(expanded, shared) do
+      shared
+    else
+      expand_common_require_groups(expanded, dep_map, module_set, entry_path)
+    end
   end
 
   defp append_unique(items, item) do

--- a/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.build.ex
+++ b/apps/duskmoon_bundler/lib/mix/tasks/duskmoon_bundler.build.ex
@@ -27,7 +27,8 @@ defmodule Mix.Tasks.DuskmoonBundler.Build do
     * `--no-code-splitting` — disable chunk splitting
     * `--no-tree-shaking` — preserve unused exports
     * `--mode` — build mode for env variables (default: `"production"`)
-    * `--format` — output format: `iife`, `esm`, or `cjs` (default from config)
+    * `--format` — standalone output format: `iife`, `esm`, or `cjs` (default from config).
+      Multi-file code-split output always uses ESM.
     * `--tailwind` — build Tailwind CSS
     * `--tailwind-css` — custom Tailwind input CSS file
     * `--tailwind-source` — source directory for Tailwind scanning (repeatable)

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/builder_test.exs
@@ -769,6 +769,82 @@ defmodule DuskmoonBundler.BuilderTest do
                  "two-markdown-html-markdown-svg-markdown-stringify-renderer-html\n"
     end
 
+    test "falls back when a common chunk would conflate default exports" do
+      File.write!(Path.join(@fixture_dir, "src/default-a.ts"), "export default 'default-a'")
+      File.write!(Path.join(@fixture_dir, "src/default-b.ts"), "export default 'default-b'")
+
+      File.write!(Path.join(@fixture_dir, "src/defaults-lazy.ts"), """
+      import a from './default-a'
+      import b from './default-b'
+      export const value = a + ':' + b
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/defaults-entry.ts"), """
+      import a from './default-a'
+      import b from './default-b'
+      export const value = a + ':' + b
+      export const load = () => import('./defaults-lazy').then((module) => module.value)
+      """)
+
+      assert {:ok, result} =
+               DuskmoonBundler.Builder.build(
+                 entry: Path.join(@fixture_dir, "src/defaults-entry.ts"),
+                 outdir: @outdir,
+                 name: "default-collision",
+                 format: :esm,
+                 hash: false,
+                 minify: false,
+                 sourcemap: false
+               )
+
+      assert result.chunks == []
+
+      node = System.find_executable("node") || flunk("node executable not found")
+      entry_url = "file://#{result.js.path}"
+
+      assert {"default-a:default-b\ndefault-a:default-b\n", 0} =
+               System.cmd(
+                 node,
+                 [
+                   "--input-type=module",
+                   "--eval",
+                   "const app = await import('#{entry_url}'); console.log(app.value); console.log(await app.load())"
+                 ],
+                 env: [{"NODE_NO_WARNINGS", "1"}],
+                 stderr_to_stdout: true
+               )
+    end
+
+    test "falls back when a common chunk would conflate a module namespace" do
+      File.write!(Path.join(@fixture_dir, "src/namespace-shared.ts"), """
+      export const value = 'namespace-value'
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/namespace-lazy.ts"), """
+      import * as shared from './namespace-shared'
+      export const lazyValue = shared.value
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/namespace-entry.ts"), """
+      import * as shared from './namespace-shared'
+      export const entryValue = shared.value
+      export const load = () => import('./namespace-lazy').then((module) => module.lazyValue)
+      """)
+
+      assert {:ok, result} =
+               DuskmoonBundler.Builder.build(
+                 entry: Path.join(@fixture_dir, "src/namespace-entry.ts"),
+                 outdir: @outdir,
+                 format: :esm,
+                 hash: false,
+                 minify: false,
+                 sourcemap: false
+               )
+
+      assert result.chunks == []
+      assert File.read!(result.js.path) =~ "namespace-value"
+    end
+
     test "no code splitting inlines literal dynamic imports" do
       File.write!(
         Path.join(@fixture_dir, "src/no_split_lazy.ts"),
@@ -1660,9 +1736,12 @@ defmodule DuskmoonBundler.BuilderTest do
       refute js =~ ~r/\brequire\s*\(/
     end
 
-    test "resolves shared React imports from nested react-dom modules when code splitting" do
+    test "preserves a lazy React App Clip glob as an async chunk" do
       File.mkdir_p!(Path.join(@fixture_dir, "node_modules/react"))
+      File.mkdir_p!(Path.join(@fixture_dir, "node_modules/react/cjs"))
       File.mkdir_p!(Path.join(@fixture_dir, "node_modules/react-dom/cjs"))
+      File.mkdir_p!(Path.join(@fixture_dir, "src/app_clip"))
+      File.mkdir_p!(Path.join(@fixture_dir, "src/notes_workspace"))
 
       File.write!(
         Path.join(@fixture_dir, "node_modules/react/package.json"),
@@ -1671,7 +1750,12 @@ defmodule DuskmoonBundler.BuilderTest do
 
       File.write!(
         Path.join(@fixture_dir, "node_modules/react/index.js"),
-        "const singleton = 'react-singleton'; exports.createElement = function() { return 'react-element' }; exports.useState = function() { return singleton }\n"
+        "module.exports = require('./cjs/react.production.js')\n"
+      )
+
+      File.write!(
+        Path.join(@fixture_dir, "node_modules/react/cjs/react.production.js"),
+        "const singleton = { token: 'react-singleton-object' }; exports.createElement = function(Component) { return Component() }; exports.useState = function() { return singleton }; exports.singleton = singleton\n"
       )
 
       File.write!(
@@ -1686,39 +1770,109 @@ defmodule DuskmoonBundler.BuilderTest do
 
       File.write!(
         Path.join(@fixture_dir, "node_modules/react-dom/cjs/react-dom-client.production.js"),
-        "var React = require('react'); exports.createRoot = function() { return React }\n"
+        "var React = require('react'); exports.createRoot = function() { return { render: function(value) { return (value[0] === React.singleton ? 'shared-react-singleton:' : 'different-react-singleton:') + value[1] } } }\n"
       )
 
-      File.write!(Path.join(@fixture_dir, "src/react_component.ts"), """
-      import { createElement, useState } from 'react'
-      export function ReproComponent() { return createElement('p', null, useState()) }
+      File.write!(Path.join(@fixture_dir, "src/notes_workspace/NotesWorkspace.tsx"), """
+      import { useState } from 'react'
+      export function NotesWorkspace() { return [useState(), 'notes-workspace-async'] }
       """)
 
-      File.write!(Path.join(@fixture_dir, "src/react_app.ts"), """
-      import { createElement } from 'react'
+      File.write!(Path.join(@fixture_dir, "src/app_clip/mount.ts"), """
+      const workspaceModules = import.meta.glob('../notes_workspace/NotesWorkspace.tsx')
+
+      export async function loadNotesWorkspace() {
+        const module = await workspaceModules['../notes_workspace/NotesWorkspace.tsx']()
+        return module.NotesWorkspace
+      }
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/react_app_clip.ts"), """
+      import React from 'react'
       import { createRoot } from 'react-dom/client'
-      const root = createRoot()
-      void import('./react_component').then(({ ReproComponent }) => {
-        root.render(createElement(ReproComponent))
-      })
+      import { loadNotesWorkspace } from './app_clip/mount'
+
+      export async function start() {
+        const NotesWorkspace = await loadNotesWorkspace()
+        return createRoot().render(React.createElement(NotesWorkspace))
+      }
       """)
 
       assert {:ok, result} =
                DuskmoonBundler.Builder.build(
-                 entry: Path.join(@fixture_dir, "src/react_app.ts"),
+                 entry: Path.join(@fixture_dir, "src/react_app_clip.ts"),
                  outdir: @outdir,
-                 minify: true,
+                 name: "react-app-clip",
+                 format: :iife,
+                 hash: false,
+                 minify: false,
                  sourcemap: false,
                  node_modules: Path.join(@fixture_dir, "node_modules")
+               )
+
+      assert [_entry, _common, _async] = result.chunks
+
+      manifest = @outdir |> Path.join("manifest.json") |> read_manifest_entries()
+      assert [lazy_file] = manifest["react-app-clip.js"]["dynamicImports"]
+
+      entry_js = File.read!(result.js.path)
+      lazy_js = File.read!(Path.join(@outdir, lazy_file))
+      all_js = result.chunks |> Enum.map_join("\n", &File.read!(&1.path))
+
+      refute entry_js =~ "notes-workspace-async"
+      assert lazy_js =~ "notes-workspace-async"
+      assert length(Regex.scan(~r/react-singleton-object/, all_js)) == 1
+      refute all_js =~ ~r/\brequire\s*\(/
+
+      node = System.find_executable("node") || flunk("node executable not found")
+      entry_url = "file://#{result.js.path}"
+
+      assert {"shared-react-singleton:notes-workspace-async\n", 0} =
+               System.cmd(
+                 node,
+                 [
+                   "--input-type=module",
+                   "--eval",
+                   "globalThis.document = { querySelector: () => null, createElement: () => ({}), head: { appendChild: () => {} } }; globalThis.window = { dispatchEvent: () => {} }; globalThis.CustomEvent = class {}; const app = await import('#{entry_url}'); console.log(await app.start())"
+                 ],
+                 env: [{"NODE_NO_WARNINGS", "1"}],
+                 stderr_to_stdout: true
+               )
+    end
+
+    test "keeps a CommonJS entry intact when its shared require cannot be split" do
+      File.write!(Path.join(@fixture_dir, "src/cjs_shared.js"), """
+      module.exports = { value: 'shared-cjs-singleton' }
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/cjs_lazy.ts"), """
+      import shared from './cjs_shared'
+      export const lazyValue = 'lazy-' + shared.value
+      """)
+
+      File.write!(Path.join(@fixture_dir, "src/cjs_entry.js"), """
+      const shared = require('./cjs_shared')
+      globalThis.entryValue = 'entry-' + shared.value
+      void import('./cjs_lazy').then((module) => module.lazyValue)
+      """)
+
+      assert {:ok, result} =
+               DuskmoonBundler.Builder.build(
+                 entry: Path.join(@fixture_dir, "src/cjs_entry.js"),
+                 outdir: @outdir,
+                 format: :esm,
+                 hash: false,
+                 minify: false,
+                 sourcemap: false
                )
 
       assert result.chunks == []
 
       js = File.read!(result.js.path)
-      assert js =~ "react-element"
-      assert js =~ "ReproComponent"
-      assert length(Regex.scan(~r/react-singleton/, js)) == 1
-      refute js =~ ~r/\brequire\s*\(/, js
+      assert js =~ "entry-"
+      assert js =~ "lazy-"
+      assert js =~ "shared-cjs-singleton"
+      refute js =~ ~r/\brequire\s*\(/
     end
 
     test "resolves package subpath without exports field" do

--- a/apps/duskmoon_bundler/test/duskmoon_bundler/chunk_graph_test.exs
+++ b/apps/duskmoon_bundler/test/duskmoon_bundler/chunk_graph_test.exs
@@ -68,6 +68,65 @@ defmodule DuskmoonBundler.ChunkGraphTest do
       assert "/app/shared.ts" in common.modules
     end
 
+    test "keeps CommonJS require chains with a shared singleton" do
+      modules = [
+        {"/app/main.ts", "main.ts", ""},
+        {"/app/node_modules/react/index.js", "react/index.js", ""},
+        {"/app/node_modules/react-dom/client.js", "react-dom/client.js", ""},
+        {"/app/node_modules/react-dom/cjs/client.js", "react-dom/cjs/client.js", ""},
+        {"/app/lazy.ts", "lazy.ts", ""}
+      ]
+
+      react = "/app/node_modules/react/index.js"
+      react_dom = "/app/node_modules/react-dom/client.js"
+      react_dom_client = "/app/node_modules/react-dom/cjs/client.js"
+
+      dep_map = %{
+        "/app/main.ts" => %{
+          static: [react, react_dom],
+          dynamic: ["/app/lazy.ts"],
+          requires: []
+        },
+        react => %{static: [], dynamic: [], requires: []},
+        react_dom => %{static: [react_dom_client], dynamic: [], requires: [react_dom_client]},
+        react_dom_client => %{static: [react], dynamic: [], requires: [react]},
+        "/app/lazy.ts" => %{static: [react], dynamic: [], requires: []}
+      }
+
+      graph = ChunkGraph.build("/app/main.ts", modules, dep_map)
+
+      assert graph.module_to_chunk[react] == "common"
+      assert graph.module_to_chunk[react_dom] == "common"
+      assert graph.module_to_chunk[react_dom_client] == "common"
+      assert graph.module_to_chunk["/app/main.ts"] == "entry"
+      assert graph.module_to_chunk["/app/lazy.ts"] not in ["entry", "common"]
+    end
+
+    test "never extracts a CommonJS entry into the common chunk" do
+      react = "/app/node_modules/react/index.js"
+
+      modules = [
+        {"/app/main.js", "main.js", ""},
+        {react, "react/index.js", ""},
+        {"/app/lazy.ts", "lazy.ts", ""}
+      ]
+
+      dep_map = %{
+        "/app/main.js" => %{
+          static: [react],
+          dynamic: ["/app/lazy.ts"],
+          requires: [react]
+        },
+        react => %{static: ["/app/main.js"], dynamic: [], requires: ["/app/main.js"]},
+        "/app/lazy.ts" => %{static: [react], dynamic: [], requires: []}
+      }
+
+      graph = ChunkGraph.build("/app/main.js", modules, dep_map)
+
+      assert graph.module_to_chunk["/app/main.js"] == "entry"
+      assert graph.module_to_chunk[react] == "common"
+    end
+
     test "extracts modules shared by async chunks even when entry does not import them" do
       modules = [
         {"/app/main.ts", "main.ts", ""},


### PR DESCRIPTION
## Summary

- preserve `import.meta.glob()` lazy boundaries for React App Clips by co-locating shared CommonJS require groups
- emit the live named/default bindings required by common-chunk consumers while retaining safe single-bundle fallbacks for ambiguous facades
- make ESM normalization for multi-file split output explicit in the CLI and documentation

## Verification

- `mix test apps/duskmoon_bundler/test` — 2 doctests, 455 tests, 0 failures
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`

Fixes #152