### PR TITLE
fix(npm): re-resolve all packages on update

### DIFF
--- a/apps/duskmoon_npm/CHANGELOG.md
+++ b/apps/duskmoon_npm/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- `mix npm.update` now re-resolves matching lock entries instead of reusing stale versions that still satisfy manifest ranges.
+
 ## 0.7.4
 
 ### Fixed

--- a/apps/duskmoon_npm/lib/npm.ex
+++ b/apps/duskmoon_npm/lib/npm.ex
@@ -131,7 +131,7 @@ defmodule NPM do
     with_root_dir(fn ->
       with {:ok, project} <- NPM.Workspace.read_all(),
            {:ok, deps} <- NPM.Workspace.install_dependencies(project) do
-        do_install(deps, local_links: project.local_links)
+        do_install(deps, local_links: project.local_links, force_resolve: true)
       end
     end)
   end
@@ -240,7 +240,11 @@ defmodule NPM do
     if opts[:frozen] do
       frozen_install(deps, Keyword.get(opts, :local_links, %{}))
     else
-      full_install(deps, Keyword.get(opts, :local_links, %{}))
+      full_install(
+        deps,
+        Keyword.get(opts, :local_links, %{}),
+        Keyword.get(opts, :force_resolve, false)
+      )
     end
   end
 
@@ -315,7 +319,7 @@ defmodule NPM do
     Map.keys(entry.dependencies) ++ Map.keys(Map.get(entry, :optional_dependencies, %{}))
   end
 
-  defp full_install(deps, local_links) do
+  defp full_install(deps, local_links, force_resolve?) do
     validate_direct_exotic_deps!(deps)
     {:ok, old_lockfile} = NPM.Lockfile.read()
 
@@ -326,6 +330,9 @@ defmodule NPM do
     nm_intact? = matches? and node_modules_intact?(old_lockfile, local_links)
 
     cond do
+      force_resolve? ->
+        resolve_and_install(deps, old_lockfile, local_links)
+
       old_lockfile == %{} ->
         resolve_and_install(deps, old_lockfile, local_links)
 

--- a/apps/duskmoon_npm/test/npm/install_test.exs
+++ b/apps/duskmoon_npm/test/npm/install_test.exs
@@ -430,6 +430,42 @@ defmodule NPM.InstallTest do
     assert lockfile[package].version == new_version
   end
 
+  test "update re-resolves matching workspace lock entries", %{project_dir: project_dir} do
+    package = "workspace-update-package"
+    range = "^1.0.0"
+    old_version = "1.0.0"
+    new_version = "1.1.0"
+    write_cached_package!(package, old_version)
+    new_cache_path = write_cached_package!(package, new_version)
+    app_dir = Path.join([project_dir, "apps", "web"])
+
+    put_packument!(package, new_version)
+
+    write_package!(project_dir, %{
+      "name" => "workspace_root",
+      "private" => true,
+      "workspaces" => ["apps/*"]
+    })
+
+    write_package!(app_dir, %{
+      "name" => "web",
+      "version" => "1.0.0",
+      "dependencies" => %{package => range}
+    })
+
+    assert :ok = NPM.Lockfile.write(%{package => lock_entry(package, old_version)})
+    File.cd!(app_dir)
+
+    capture_io(fn ->
+      assert :ok = NPM.update()
+    end)
+
+    assert {:ok, %{^package => %{version: ^new_version}}} =
+             NPM.Lockfile.read(Path.join(project_dir, "package-lock.json"))
+
+    assert_copied_package(new_cache_path, Path.join([project_dir, "node_modules", package]))
+  end
+
   test "adds dependencies to workspace package and installs at workspace root", %{
     project_dir: project_dir
   } do


### PR DESCRIPTION
## Summary

- make `NPM.update/0` bypass the matching-lock install fast path and re-resolve every workspace dependency
- preserve the previous lockfile until resolution succeeds so diffs and failure recovery remain intact
- add a workspace regression proving a matching `^1.0.0` lock advances from `1.0.0` to `1.1.0`

## Verification

- `mix test apps/duskmoon_npm/test` — 60 tests, 0 failures
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix format --check-formatted`

Fixes #153