### PR TITLE
fix: resolve UI form and npm workspace requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Components that require hooks:
 <.dm_btn variant="primary">Click me</.dm_btn>
 <.dm_btn variant="secondary" loading={@loading}>Loading</.dm_btn>
 <.dm_btn variant="error" shape="circle">×</.dm_btn>
+<.dm_btn native_submit variant="primary">Submit without JavaScript</.dm_btn>
 ```
 
 ### Cards
@@ -135,6 +136,7 @@ Components that require hooks:
 | `shape`   | `square`, `circle` |
 | `loading` | boolean |
 | `disabled`| boolean |
+| `native_submit` | boolean; render a native no-JavaScript submit control |
 | `class`   | additional CSS classes |
 
 

--- a/apps/duskmoon_npm/CHANGELOG.md
+++ b/apps/duskmoon_npm/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - `mix npm.update` now re-resolves matching lock entries instead of reusing stale versions that still satisfy manifest ranges.
+- Remove workspace-local installs during `mix npm.rebuild` and reject them during `mix npm.verify` before they can shadow root lockfile packages.
 
 ## 0.7.4
 

--- a/apps/duskmoon_npm/guides/reference/mix-tasks.md
+++ b/apps/duskmoon_npm/guides/reference/mix-tasks.md
@@ -16,7 +16,7 @@ npm_ex exposes npm-like workflows as Mix tasks.
 | `mix npm.update package` | update one package |
 | `mix npm.remove package` | remove a package |
 | `mix npm.prune` | remove extraneous packages |
-| `mix npm.rebuild` | clean and reinstall from lockfile |
+| `mix npm.rebuild` | clean root and workspace-local installs, then reinstall from lockfile |
 
 ## Inspect dependency state
 
@@ -53,7 +53,8 @@ npm_ex exposes npm-like workflows as Mix tasks.
 
 | Task | Purpose |
 | --- | --- |
-| `mix npm.verify` / `mix npm.check` | verify `node_modules` matches `package-lock.json` |
+| `mix npm.verify` | verify root `node_modules` matches the lockfile and no workspace-local install shadows it |
+| `mix npm.check` | run basic manifest, lockfile, and install-presence checks |
 | `mix npm.audit` | npm registry vulnerability audit |
 | `mix npm.audit --osv` | online OSV malicious-package audit |
 | `mix npm.audit --compromised` | offline malicious-package DB audit |

--- a/apps/duskmoon_npm/lib/mix/tasks/npm.rebuild.ex
+++ b/apps/duskmoon_npm/lib/mix/tasks/npm.rebuild.ex
@@ -2,11 +2,13 @@ defmodule Mix.Tasks.Npm.Rebuild do
   @shortdoc "Rebuild node_modules from lockfile"
 
   @moduledoc """
-  Remove `node_modules/` and reinstall from the lockfile.
+  Remove root and workspace-local `node_modules/` directories, then reinstall
+  from the root lockfile.
 
       mix npm.rebuild
 
-  Equivalent to `mix npm.clean` followed by `mix npm.get`.
+  Unlike `mix npm.clean`, this also removes installs nested under declared npm
+  workspaces so they cannot shadow packages restored at the root.
   """
 
   use Mix.Task
@@ -15,15 +17,44 @@ defmodule Mix.Tasks.Npm.Rebuild do
   def run([]) do
     Application.ensure_all_started(:req)
 
-    if File.exists?("node_modules") do
-      File.rm_rf!("node_modules")
-      Mix.shell().info("Removed node_modules/")
-    end
+    case NPM.Workspace.manifests() do
+      {:ok, manifests} ->
+        remove_node_modules(manifests)
+        NPM.get()
 
-    NPM.get()
+      {:error, reason} ->
+        Mix.raise("npm.rebuild failed: #{inspect(reason)}")
+    end
   end
 
   def run(_) do
     Mix.shell().error("Usage: mix npm.rebuild")
+  end
+
+  defp remove_node_modules(manifests) do
+    root_dir = manifests |> Enum.find(& &1.root?) |> Map.fetch!(:dir)
+    node_modules_dirs = Enum.map(manifests, &Path.join(&1.dir, "node_modules"))
+
+    case Enum.find(node_modules_dirs, &(not inside_dir?(root_dir, &1))) do
+      nil ->
+        Enum.each(node_modules_dirs, &remove_node_modules(&1, root_dir))
+
+      outside_dir ->
+        Mix.raise("npm.rebuild refused workspace outside root: #{outside_dir}")
+    end
+  end
+
+  defp remove_node_modules(node_modules, root_dir) do
+    if File.exists?(node_modules) do
+      File.rm_rf!(node_modules)
+      Mix.shell().info("Removed #{Path.relative_to(node_modules, root_dir)}/")
+    end
+  end
+
+  defp inside_dir?(parent, child) do
+    parent = parent |> Path.expand() |> Path.split()
+    child = child |> Path.expand() |> Path.split()
+
+    List.starts_with?(child, parent)
   end
 end

--- a/apps/duskmoon_npm/lib/mix/tasks/npm.verify.ex
+++ b/apps/duskmoon_npm/lib/mix/tasks/npm.verify.ex
@@ -6,8 +6,9 @@ defmodule Mix.Tasks.Npm.Verify do
 
       mix npm.verify
 
-  Reports missing and extraneous packages. Useful for CI
-  to ensure `mix npm.get` was run after lockfile changes.
+  Reports missing and extraneous packages, plus packages in workspace-local
+  `node_modules/` directories that can shadow the root installation. Useful
+  for CI to ensure `mix npm.get` was run after lockfile changes.
   """
 
   use Mix.Task
@@ -21,16 +22,17 @@ defmodule Mix.Tasks.Npm.Verify do
         Mix.shell().info("No lockfile. Nothing to verify.")
 
       {:ok, lockfile} ->
-        case NPM.Workspace.read_all() do
-          {:ok, project} ->
-            expected = expected_packages(lockfile, project.local_links)
-            skipped = NPM.Install.Linker.skipped_packages(lockfile)
+        with {:ok, project} <- NPM.Workspace.read_all(),
+             {:ok, manifests} <- NPM.Workspace.manifests() do
+          expected = expected_packages(lockfile, project.local_links)
+          skipped = NPM.Install.Linker.skipped_packages(lockfile)
+          shadowing = workspace_shadowing_packages(manifests)
 
-            expected
-            |> NPM.NodeModules.diff()
-            |> ignore_missing(skipped)
-            |> report_diff(map_size(expected) - MapSet.size(skipped))
-
+          expected
+          |> NPM.NodeModules.diff()
+          |> ignore_missing(skipped)
+          |> report_diff(shadowing, map_size(expected) - MapSet.size(skipped))
+        else
           {:error, reason} ->
             Mix.raise("npm.verify failed: #{inspect(reason)}")
         end
@@ -52,13 +54,30 @@ defmodule Mix.Tasks.Npm.Verify do
     {Enum.reject(missing, &MapSet.member?(skipped, &1)), extra}
   end
 
-  defp report_diff({[], []}, count) do
+  defp workspace_shadowing_packages(manifests) do
+    root_dir = manifests |> Enum.find(& &1.root?) |> Map.fetch!(:dir)
+
+    manifests
+    |> Enum.reject(& &1.root?)
+    |> Enum.flat_map(fn manifest ->
+      node_modules = Path.join(manifest.dir, "node_modules")
+      relative_dir = Path.relative_to(node_modules, root_dir)
+
+      node_modules
+      |> NPM.NodeModules.installed()
+      |> Enum.map(&Path.join(relative_dir, &1))
+    end)
+    |> Enum.sort()
+  end
+
+  defp report_diff({[], []}, [], count) do
     Mix.shell().info("node_modules matches lockfile (#{count} packages)")
   end
 
-  defp report_diff({missing, extra}, _count) do
+  defp report_diff({missing, extra}, shadowing, _count) do
     Enum.each(missing, &Mix.shell().error("  missing: #{&1}"))
     Enum.each(extra, &Mix.shell().error("  extra: #{&1}"))
+    Enum.each(shadowing, &Mix.shell().error("  shadowing: #{&1}"))
     Mix.raise("node_modules does not match lockfile")
   end
 end

--- a/apps/duskmoon_npm/test/mix/tasks/npm_rebuild_test.exs
+++ b/apps/duskmoon_npm/test/mix/tasks/npm_rebuild_test.exs
@@ -1,0 +1,86 @@
+defmodule Mix.Tasks.Npm.RebuildTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  setup do
+    old_cwd = File.cwd!()
+
+    tmp_dir =
+      Path.join([
+        System.tmp_dir!(),
+        "npm_rebuild_test_#{System.unique_integer([:positive])}"
+      ])
+
+    project_dir = Path.join(tmp_dir, "project")
+    File.mkdir_p!(project_dir)
+    File.cd!(project_dir)
+
+    write_package!(".", %{
+      "name" => "rebuild-test",
+      "private" => true,
+      "workspaces" => ["apps/*"]
+    })
+
+    write_package!(Path.join(["apps", "web"]), %{
+      "name" => "web",
+      "version" => "1.0.0"
+    })
+
+    on_exit(fn ->
+      File.cd!(old_cwd)
+      File.rm_rf!(tmp_dir)
+    end)
+
+    :ok
+  end
+
+  test "removes root and workspace-local node_modules before rebuilding" do
+    root_node_modules = "node_modules"
+    workspace_node_modules = Path.join(["apps", "web", "node_modules"])
+    unmanaged_node_modules = Path.join(["vendor", "other", "node_modules"])
+
+    File.mkdir_p!(Path.join(root_node_modules, "current"))
+    File.mkdir_p!(Path.join(workspace_node_modules, "stale"))
+    File.mkdir_p!(Path.join(unmanaged_node_modules, "preserved"))
+
+    output =
+      capture_io(fn ->
+        assert :ok = Mix.Tasks.Npm.Rebuild.run([])
+      end)
+
+    refute File.exists?(root_node_modules)
+    refute File.exists?(workspace_node_modules)
+    assert File.exists?(unmanaged_node_modules)
+    assert output =~ "Removed node_modules/"
+    assert output =~ "Removed apps/web/node_modules/"
+  end
+
+  test "refuses to remove node_modules outside the workspace root" do
+    outside_dir = Path.expand("../outside-workspace")
+    root_node_modules = "node_modules"
+    outside_node_modules = Path.join(outside_dir, "node_modules")
+
+    write_package!(".", %{
+      "name" => "rebuild-test",
+      "private" => true,
+      "workspaces" => ["../outside-workspace"]
+    })
+
+    write_package!(outside_dir, %{"name" => "outside-workspace", "version" => "1.0.0"})
+    File.mkdir_p!(Path.join(root_node_modules, "preserved"))
+    File.mkdir_p!(Path.join(outside_node_modules, "preserved"))
+
+    assert_raise Mix.Error, ~r/npm\.rebuild refused workspace outside root/, fn ->
+      Mix.Tasks.Npm.Rebuild.run([])
+    end
+
+    assert File.exists?(root_node_modules)
+    assert File.exists?(outside_node_modules)
+  end
+
+  defp write_package!(dir, data) do
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "package.json"), NPM.JSON.encode_pretty(data))
+  end
+end

--- a/apps/duskmoon_npm/test/mix/tasks/npm_verify_test.exs
+++ b/apps/duskmoon_npm/test/mix/tasks/npm_verify_test.exs
@@ -93,6 +93,49 @@ defmodule Mix.Tasks.Npm.VerifyTest do
     assert output =~ "extra: extra"
   end
 
+  test "raises when workspace node_modules can shadow a root package" do
+    package = "@duskmoon-dev/core"
+    workspace_dir = Path.join(["apps", "sigma_web"])
+
+    write_package!(".", %{
+      "name" => "sigma",
+      "private" => true,
+      "workspaces" => ["apps/*"]
+    })
+
+    write_package!(workspace_dir, %{
+      "name" => "sigma-web",
+      "version" => "1.0.0",
+      "dependencies" => %{package => "1.18.4"}
+    })
+
+    write_lockfile!(%{package => lock_entry()})
+
+    write_package!(Path.join(["node_modules", package]), %{
+      "name" => package,
+      "version" => "1.18.4"
+    })
+
+    write_package!(Path.join(["node_modules", "sigma-web"]), %{
+      "name" => "sigma-web",
+      "version" => "1.0.0"
+    })
+
+    write_package!(Path.join([workspace_dir, "node_modules", package]), %{
+      "name" => package,
+      "version" => "1.17.0"
+    })
+
+    output =
+      capture_io(:stderr, fn ->
+        assert_raise Mix.Error, ~r/node_modules does not match lockfile/, fn ->
+          Mix.Tasks.Npm.Verify.run([])
+        end
+      end)
+
+    assert output =~ "shadowing: apps/sigma_web/node_modules/@duskmoon-dev/core"
+  end
+
   test "raises when the lockfile cannot be read" do
     File.mkdir_p!("package-lock.json")
 
@@ -103,6 +146,11 @@ defmodule Mix.Tasks.Npm.VerifyTest do
 
   defp write_lockfile!(lockfile) do
     assert :ok = NPM.Lockfile.write(lockfile)
+  end
+
+  defp write_package!(dir, data) do
+    File.mkdir_p!(dir)
+    File.write!(Path.join(dir, "package.json"), NPM.JSON.encode_pretty(data))
   end
 
   defp lock_entry(opts \\ []) do

--- a/apps/duskmoon_storybook/storybook/action/button.story.exs
+++ b/apps/duskmoon_storybook/storybook/action/button.story.exs
@@ -92,6 +92,18 @@ defmodule Storybook.Action.Button do
         ]
       },
 
+      # ── Native Form Submission ───────────────────────────────────────
+      %Variation{
+        id: :native_submit,
+        description: "Native form submit control that works without JavaScript",
+        attributes: %{
+          native_submit: true,
+          variant: "primary",
+          form: "settings-form"
+        },
+        slots: ["Save without JavaScript"]
+      },
+
       # ── Slots ─────────────────────────────────────────────────────────
       %VariationGroup{
         id: :slots,
@@ -261,6 +273,12 @@ defmodule Storybook.Action.Button do
       %{
         id: :disabled,
         label: "Disabled",
+        type: :boolean,
+        default: false
+      },
+      %{
+        id: :native_submit,
+        label: "Native submit",
         type: :boolean,
         default: false
       }

--- a/apps/duskmoon_storybook/storybook/layout/theme_switcher.story.exs
+++ b/apps/duskmoon_storybook/storybook/layout/theme_switcher.story.exs
@@ -26,6 +26,15 @@ defmodule Storybook.Layout.ThemeSwitcher do
         attributes: %{
           theme: "moonlight"
         }
+      },
+      %Variation{
+        id: :icon_only,
+        description: "Compact icon-only trigger with an accessible name",
+        attributes: %{
+          class: "theme-controller-dropdown-icon",
+          select_theme_label: "Select theme"
+        },
+        slots: [~s(<:trigger><span aria-hidden="true">◐</span></:trigger>)]
       }
     ]
   end

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/action/button.ex
@@ -2,13 +2,16 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
   @moduledoc """
   Button component using el-dm-button custom element.
 
-  Provides three button modes:
+  Provides four button modes:
   - Standard button with variants and sizes
+  - Native submit button for forms that must work without JavaScript
   - Button with confirmation modal (Invoker Commands API)
   - Noise effect button (decorative)
 
   When `command` / `commandfor` are set, renders a native `<button>` so the
   Invoker Commands API works (custom element hosts are not valid invokers).
+  Set `native_submit` to render a native `<button type="submit">` without the
+  custom element submit bridge.
 
   ## Examples
 
@@ -17,6 +20,8 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
       <.dm_btn variant="primary" size="lg">Primary</.dm_btn>
 
       <.dm_btn variant="error" confirm="Are you sure?">Delete</.dm_btn>
+
+      <.dm_btn native_submit variant="primary">Save</.dm_btn>
 
       <.dm_btn command="show-modal" commandfor="my-modal">Open</.dm_btn>
 
@@ -74,6 +79,8 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
 
       <.dm_btn navigate="/dashboard" variant="ghost">Dashboard</.dm_btn>
 
+      <.dm_btn native_submit variant="primary">Save</.dm_btn>
+
       <.dm_btn confirm="Are you sure?" confirm_title="Confirm Action">Delete</.dm_btn>
 
   """
@@ -113,6 +120,11 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
 
   attr(:loading, :boolean, default: false, doc: "Show loading state")
   attr(:disabled, :boolean, default: false, doc: "Disable the button")
+
+  attr(:native_submit, :boolean,
+    default: false,
+    doc: "Render a native submit button for forms that must work without JavaScript"
+  )
 
   attr(:navigate, :string,
     default: nil,
@@ -187,7 +199,7 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
       assigns
       |> assign(:id, id)
       |> assign(:dialog_id, dialog_id)
-      |> assign(:confirm_rest, confirm_rest(assigns.rest, dialog_id))
+      |> assign(:confirm_rest, confirm_rest(assigns.rest, dialog_id, assigns.native_submit))
       |> assign_button_style()
       |> then(fn assigns ->
         assigns
@@ -251,6 +263,14 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
     """
   end
 
+  def dm_btn(%{native_submit: true} = assigns) do
+    assigns = assign_native_submit_button(assigns)
+
+    ~H"""
+    <.button_native {assigns} />
+    """
+  end
+
   def dm_btn(%{noise: true} = assigns) do
     assigns =
       assigns
@@ -298,8 +318,11 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
     """
   end
 
-  defp confirm_rest(rest, dialog_id) do
-    rest = put_new_rest_attr(rest, :type, "type", "button")
+  defp confirm_rest(rest, dialog_id, native_submit) do
+    rest =
+      if native_submit,
+        do: put_rest_attr(rest, :type, "type", "submit"),
+        else: put_new_rest_attr(rest, :type, "type", "button")
 
     if has_rest_attr?(rest, :command, "command") ||
          has_rest_attr?(rest, :commandfor, "commandfor") do
@@ -315,6 +338,12 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
     if has_rest_attr?(rest, atom_key, string_key),
       do: rest,
       else: Map.put(rest, string_key, value)
+  end
+
+  defp put_rest_attr(rest, atom_key, string_key, value) do
+    rest
+    |> Map.delete(atom_key)
+    |> Map.put(string_key, value)
   end
 
   defp has_rest_attr?(rest, atom_key, string_key),
@@ -342,6 +371,16 @@ defmodule PhoenixDuskmoon.Component.Action.Button do
     assigns
     |> assign(:rest, rest_without_onclick(assigns.rest, submit_onclick))
     |> assign(:submit_onclick, submit_onclick)
+    |> assign_button_style()
+    |> then(fn assigns ->
+      assign(assigns, :button_class, btn_class_list(assigns))
+    end)
+  end
+
+  defp assign_native_submit_button(assigns) do
+    assigns
+    |> assign(:rest, put_rest_attr(assigns.rest, :type, "type", "submit"))
+    |> assign(:submit_onclick, nil)
     |> assign_button_style()
     |> then(fn assigns ->
       assign(assigns, :button_class, btn_class_list(assigns))

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_entry/input.ex
@@ -313,6 +313,8 @@ defmodule PhoenixDuskmoon.Component.DataEntry.Input do
   end
 
   defp dm_input_by_type(%{type: "select"} = assigns) do
+    assigns = assign_new(assigns, :value, fn -> nil end)
+
     ~H"""
     <div class={["form-group", @horizontal && "form-group-horizontal", @errors != [] && "form-group-error", @state && "form-group-#{@state}", @field_class]} phx-feedback-for={@name}>
       <.dm_label for={@id} class={@label_class}>{@label}</.dm_label>

--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/layout/theme_switcher.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/layout/theme_switcher.ex
@@ -20,6 +20,9 @@ defmodule PhoenixDuskmoon.Component.Layout.ThemeSwitcher do
       <.dm_theme_switcher />
       <.dm_theme_switcher theme="moonlight" />
       <.dm_theme_switcher button_text="Thème" auto_label="Auto" light_label="Clair" dark_label="Sombre" />
+      <.dm_theme_switcher class="theme-controller-dropdown-icon" select_theme_label="Select theme">
+        <:trigger><.dm_mdi name="theme-light-dark" aria-hidden="true" /></:trigger>
+      </.dm_theme_switcher>
 
   """
   @doc type: :component
@@ -38,6 +41,8 @@ defmodule PhoenixDuskmoon.Component.Layout.ThemeSwitcher do
   attr(:dark_label, :string, default: "Moonlight", doc: "Label for the dark theme option")
   attr(:rest, :global, doc: "additional HTML attributes")
 
+  slot(:trigger, doc: "Optional trigger content; replaces button_text when provided")
+
   def dm_theme_switcher(assigns) do
     assigns =
       assigns
@@ -55,7 +60,11 @@ defmodule PhoenixDuskmoon.Component.Layout.ThemeSwitcher do
       {@rest}
     >
       <summary class="theme-controller-trigger" aria-label={@select_theme_label} aria-haspopup="menu">
-        {@button_text}
+        <%= if @trigger == [] do %>
+          {@button_text}
+        <% else %>
+          {render_slot(@trigger)}
+        <% end %>
       </summary>
       <div class="theme-controller-menu" role="radiogroup" aria-label={@select_theme_label}>
         <input

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_browser_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_browser_test.exs
@@ -179,6 +179,74 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonBrowserTest do
              """)
   end
 
+  test "native submit mode submits without the component JavaScript runtime", %{page: page} do
+    save =
+      render_component(&dm_btn/1, %{
+        native_submit: true,
+        id: "save-settings",
+        form: "settings-form",
+        name: "action",
+        value: "save",
+        inner_block: %{inner_block: fn _, _ -> "Save" end}
+      })
+
+    delete =
+      render_component(&dm_btn/1, %{
+        native_submit: true,
+        id: "delete-settings",
+        form: "settings-form",
+        name: "action",
+        value: "delete",
+        confirm: "Delete these settings?",
+        inner_block: %{inner_block: fn _, _ -> "Delete" end}
+      })
+
+    html =
+      "<!doctype html><html lang=\"en\"><body><form id=\"settings-form\">#{save}#{delete}</form></body></html>"
+
+    url = "data:text/html;base64," <> Base.encode64(html)
+
+    :ok = CDPBrowser.goto(page, url)
+
+    assert {:ok,
+            %{
+              "confirmOpened" => true,
+              "directType" => "submit",
+              "submissions" => [
+                %{"name" => "action", "value" => "save"},
+                %{"name" => "action", "value" => "delete"}
+              ]
+            }} =
+             CDPBrowser.evaluate(page, """
+             (() => {
+               const form = document.getElementById("settings-form")
+               const save = document.getElementById("save-settings")
+               const deleteTrigger = document.getElementById("delete-settings")
+               const dialog = document.getElementById("confirm-dialog-delete-settings")
+               const submissions = []
+
+               form.addEventListener("submit", (event) => {
+                 event.preventDefault()
+                 submissions.push({
+                   name: event.submitter.name,
+                   value: event.submitter.value
+                 })
+               })
+
+               save.click()
+               deleteTrigger.click()
+               const confirmOpened = dialog.open && dialog.matches(":modal")
+               dialog.querySelector("[data-dm-confirm-action]").click()
+
+               return {
+                 directType: save.type,
+                 confirmOpened,
+                 submissions
+               }
+             })()
+             """)
+  end
+
   defp dispatch_key(page, key, code, key_code, modifiers \\ 0) do
     params = %{
       "key" => key,

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/action/button_test.exs
@@ -653,6 +653,58 @@ defmodule PhoenixDuskmoon.Component.Action.ButtonTest do
     assert result =~ ~s[value="save"]
   end
 
+  test "renders opt-in native submit control for no-JS forms" do
+    result =
+      render_component(&dm_btn/1, %{
+        native_submit: true,
+        id: "save-settings",
+        variant: "error",
+        size: "lg",
+        shape: "square",
+        class: "settings-submit",
+        form: "settings-form",
+        name: "action",
+        value: "save",
+        "aria-label": "Save settings",
+        "data-testid": "settings-submit",
+        inner_block: %{inner_block: fn _, _ -> "Save" end}
+      })
+
+    assert [_] = Regex.scan(~r/<button\b/, result)
+    assert result =~ ~s[type="submit"]
+    assert result =~ ~s[class="btn btn-primary btn-lg btn-square settings-submit"]
+    assert result =~ "--color-primary: var(--color-error)"
+    assert result =~ ~s[form="settings-form"]
+    assert result =~ ~s[name="action"]
+    assert result =~ ~s[value="save"]
+    assert result =~ ~s[aria-label="Save settings"]
+    assert result =~ ~s[data-testid="settings-submit"]
+    refute result =~ "<el-dm-button"
+    refute result =~ "requestSubmit"
+  end
+
+  test "native submit confirmation keeps the confirmed action as the submitter" do
+    result =
+      render_component(&dm_btn/1, %{
+        native_submit: true,
+        id: "delete-settings",
+        variant: "error",
+        confirm: "Delete these settings?",
+        form: "settings-form",
+        name: "action",
+        value: "delete",
+        inner_block: %{inner_block: fn _, _ -> "Delete" end}
+      })
+
+    assert result =~ ~s[command="show-modal"]
+    assert result =~ ~s[data-dm-confirm-action="true"]
+    assert [_] = Regex.scan(~r/<button\b[^>]*type="submit"[^>]*>/, result)
+    assert result =~ ~s[form="settings-form"]
+    assert result =~ ~s[name="action"]
+    assert result =~ ~s[value="delete"]
+    refute result =~ "requestSubmit"
+  end
+
   test "renders submit button with native form submit bridge" do
     result =
       render_component(&dm_btn/1, %{

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_entry/input_test.exs
@@ -3,6 +3,7 @@ defmodule PhoenixDuskmoon.Component.DataEntry.InputTest do
 
   require Phoenix.LiveViewTest
   import Phoenix.LiveViewTest
+  import Phoenix.Component
   import PhoenixDuskmoon.Component.DataEntry.Input
 
   describe "generic input type" do
@@ -93,6 +94,27 @@ defmodule PhoenixDuskmoon.Component.DataEntry.InputTest do
 
       assert result =~ ~s[<option]
       assert result =~ "Choose an option"
+    end
+
+    test "renders select with prompt when the optional value is omitted" do
+      assigns = %{}
+
+      result =
+        rendered_to_string(~H"""
+          <.dm_input
+            id="github-account"
+            name="import[github_identity_id]"
+            type="select"
+            prompt="Choose an account"
+            options={[{"Github:octocat", 41}]}
+          />
+        """)
+
+      assert result =~ ~s[id="github-account"]
+      assert result =~ ~s{name="import[github_identity_id]"}
+
+      assert result =~
+               ~r{<option value="">Choose an account</option>\s*<option value="41">Github:octocat</option>}
     end
 
     test "renders select with multiple attribute" do

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/layout/theme_switcher_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/layout/theme_switcher_test.exs
@@ -159,6 +159,35 @@ defmodule PhoenixDuskmoon.Component.Layout.ThemeSwitcherTest do
     assert result =~ "Thème"
   end
 
+  test "renders an icon-only trigger slot while preserving switcher behavior" do
+    trigger = [
+      %{
+        __slot__: :trigger,
+        inner_block: fn _, _ ->
+          Phoenix.HTML.raw(~s(<svg data-testid="theme-icon" aria-hidden="true"></svg>))
+        end
+      }
+    ]
+
+    result =
+      render_component(&dm_theme_switcher/1, %{
+        button_text: "Text fallback",
+        class: "theme-controller-dropdown-icon",
+        select_theme_label: "Choose appearance",
+        trigger: trigger
+      })
+
+    assert result =~
+             ~r/<summary[^>]*aria-label="Choose appearance"[^>]*>.*data-testid="theme-icon".*<\/summary>/s
+
+    refute result =~ "Text fallback"
+    assert result =~ "theme-controller-dropdown-icon"
+    assert result =~ ~s[phx-hook="ThemeSwitcher"]
+    assert result =~ ~s[value="default"]
+    assert result =~ ~s[value="sunshine"]
+    assert result =~ ~s[value="moonlight"]
+  end
+
   test "renders with custom auto_label" do
     result = render_component(&dm_theme_switcher/1, %{auto_label: "Automatique"})
 


### PR DESCRIPTION
## Summary

- add an accessible icon-only trigger slot to `dm_theme_switcher`
- add opt-in native no-JavaScript submission, including confirmation, to `dm_btn`
- allow `dm_input` selects to omit `value` while rendering their prompt
- remove stale declared-workspace installs during `mix npm.rebuild` and reject shadowing workspace packages during `mix npm.verify`
- document the new component and NPM task behavior in Storybook and package guides

## Validation

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test apps/phoenix_duskmoon/test` — 3,150 tests, 0 failures
- `mix test apps/duskmoon_npm/test` — 63 tests, 0 failures
- real Chromium coverage for direct and confirmed native form submit without the component JavaScript runtime
- `git diff --check`

Fixes #156
Fixes #157
Fixes #158
Fixes #159