### PR TITLE
fix: render simple appbar profile once

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/navigation/appbar.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/navigation/appbar.ex
@@ -18,7 +18,6 @@ defmodule PhoenixDuskmoon.Component.Navigation.Appbar do
 
   import PhoenixDuskmoon.Component.Action.Link
   import PhoenixDuskmoon.Component.Icon.Icons
-  import PhoenixDuskmoon.Component.Layout.Divider
 
   @doc """
   Generates an appbar using `@duskmoon-dev/core` CSS classes.
@@ -105,6 +104,8 @@ defmodule PhoenixDuskmoon.Component.Navigation.Appbar do
   @doc """
   Generates a simple responsive HTML appbar with mobile menu toggle.
 
+  The user profile is rendered once in the header at all screen sizes.
+
   ## Example
 
       <.dm_simple_appbar title="PhoenixDuskmoon">
@@ -175,7 +176,7 @@ defmodule PhoenixDuskmoon.Component.Navigation.Appbar do
           </nav>
         </div>
         <div class="appbar-trailing">
-          <div class="hidden md:inline-flex">
+          <div class="inline-flex">
             {render_slot(@user_profile)}
           </div>
           <button
@@ -214,10 +215,6 @@ defmodule PhoenixDuskmoon.Component.Navigation.Appbar do
         >
           {render_slot(menu)}
         </a>
-        <.dm_divider />
-        <div class="w-full text-center flex flex-col justify-start items-center">
-          {render_slot(@user_profile)}
-        </div>
       </div>
     </header>
     """

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/navigation/appbar_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/navigation/appbar_test.exs
@@ -298,15 +298,24 @@ defmodule PhoenixDuskmoon.Component.Navigation.AppbarTest do
     assert result =~ "UserArea"
   end
 
-  test "renders simple appbar with divider between menu and user_profile in mobile" do
+  test "renders simple appbar user profile once outside the collapsed mobile menu" do
     result =
       render_component(&dm_simple_appbar/1, %{
         title: "App",
-        menu: [%{to: "/a", inner_block: fn _, _ -> "A" end}],
-        user_profile: [%{inner_block: fn _, _ -> "U" end}]
+        user_profile: [
+          %{
+            inner_block: fn _, _ ->
+              Phoenix.HTML.raw(~s(<a id="admin-sign-out" href="/logout">Sign out</a>))
+            end
+          }
+        ]
       })
 
-    assert result =~ "divider"
+    assert [_before, _after] = String.split(result, ~s(id="admin-sign-out"))
+    [header, mobile_menu] = String.split(result, ~s(id="appbar-mobile-menu"))
+    assert header =~ ~s(id="admin-sign-out")
+    refute header =~ "hidden md:inline-flex"
+    refute mobile_menu =~ ~s(id="admin-sign-out")
   end
 
   test "renders appbar with all options combined" do


### PR DESCRIPTION
Rendering an interactive `user_profile` with a stable ID in `dm_simple_appbar` duplicated that ID between desktop and mobile markup, causing LiveView mount failures. Render the profile once in the header at every screen size and remove the obsolete mobile divider.

Mobile profile actions now remain available while the navigation menu is collapsed.

Validation: the regression failed before the fix; all 57 appbar tests and component compilation with warnings as errors pass. A local Chromium check with built CSS passed at 375px and 1280px, including menu open/close and profile focus/visibility.

Fixes #161
