### PR TITLE
fix: synchronize reconnect toast accessibility visibility

### DIFF
--- a/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/flash.ex
+++ b/apps/phoenix_duskmoon/lib/phoenix_duskmoon/component/data_display/flash.ex
@@ -100,8 +100,15 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.Flash do
         title={@disconnected_title}
         close={false}
         autoshow={false}
-        phx-disconnected={JS.add_class("toast-open", to: "#disconnected")}
-        phx-connected={JS.remove_class("toast-open", to: "#disconnected")}
+        aria-hidden="true"
+        phx-disconnected={
+          JS.set_attribute({"aria-hidden", "false"}, to: "#disconnected")
+          |> JS.add_class("toast-open", to: "#disconnected")
+        }
+        phx-connected={
+          JS.set_attribute({"aria-hidden", "true"}, to: "#disconnected")
+          |> JS.remove_class("toast-open", to: "#disconnected")
+        }
       >
         {@reconnecting_text} <.dm_bsi name="arrow-repeat" class="inline ml-1 w-3 h-3 animate-spin" aria-hidden="true" />
       </.dm_flash>

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/flash_browser_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/flash_browser_test.exs
@@ -1,0 +1,78 @@
+defmodule PhoenixDuskmoon.Component.DataDisplay.FlashBrowserTest do
+  use ExUnit.Case, async: false
+
+  import Phoenix.LiveViewTest
+  import PhoenixDuskmoon.Component.DataDisplay.Flash
+
+  alias DuskmoonBundler.Integration.CDPBrowser
+
+  @moduletag :integration
+
+  setup_all do
+    {:ok, browser} = CDPBrowser.start_link()
+    on_exit(fn -> CDPBrowser.stop(browser) end)
+    %{browser: browser}
+  end
+
+  test "connection commands expose the alert only while disconnected", %{browser: browser} do
+    {:ok, page} = CDPBrowser.new_page(browser)
+    on_exit(fn -> CDPBrowser.close_page(page) end)
+
+    component = render_component(&dm_flash_group/1, %{flash: %{}})
+    phoenix = File.read!(Application.app_dir(:phoenix, "priv/static/phoenix.js"))
+
+    live_view =
+      File.read!(Application.app_dir(:phoenix_live_view, "priv/static/phoenix_live_view.js"))
+
+    html = """
+    <!doctype html><html lang="en"><body>
+    <div id="flash-test" data-phx-session="test">#{component}</div>
+    <script>#{phoenix}</script><script>#{live_view}</script>
+    <script>
+      // Data URLs have no browser storage; connection commands need no persisted state.
+      const storage = {getItem: () => null, setItem: () => {}, removeItem: () => {}}
+      window.liveSocket = new LiveView.LiveSocket('ws://localhost/live', Phoenix.Socket, {
+        localStorage: storage, sessionStorage: storage
+      })
+      window.liveSocket.newRootView(document.getElementById('flash-test'))
+    </script>
+    </body></html>
+    """
+
+    :ok = CDPBrowser.goto(page, "data:text/html;base64," <> Base.encode64(html))
+
+    assert_alert_state(page, false)
+
+    for {event, exposed} <- [{"phx-disconnected", true}, {"phx-connected", false}] do
+      assert {:ok, true} =
+               CDPBrowser.evaluate(page, """
+               (async () => {
+                 const alert = document.getElementById('disconnected')
+                 window.liveSocket.execJS(alert, alert.getAttribute('#{event}'))
+                 await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+                 return true
+               })()
+               """)
+
+      assert_alert_state(page, exposed)
+    end
+  end
+
+  defp assert_alert_state(page, exposed) do
+    assert {:ok, ^exposed} =
+             CDPBrowser.evaluate(
+               page,
+               "document.getElementById('disconnected').classList.contains('toast-open')"
+             )
+
+    assert {:ok, %{"nodes" => nodes}} =
+             CDPBrowser.command(page, "Accessibility.getFullAXTree", %{}, timeout: 5_000)
+
+    alerts =
+      Enum.filter(nodes, fn node ->
+        node["ignored"] != true && get_in(node, ["role", "value"]) == "alert"
+      end)
+
+    assert length(alerts) == if(exposed, do: 1, else: 0)
+  end
+end

--- a/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/flash_test.exs
+++ b/apps/phoenix_duskmoon/test/phoenix_duskmoon/component/data_display/flash_test.exs
@@ -6,6 +6,20 @@ defmodule PhoenixDuskmoon.Component.DataDisplay.FlashTest do
   import PhoenixDuskmoon.Component.DataDisplay.Flash
 
   describe "dm_flash_group/1" do
+    test "reconnect toast starts hidden from assistive technology and synchronizes transitions" do
+      result = render_component(&dm_flash_group/1, %{flash: %{}})
+      [tag] = Regex.run(~r/<div id="disconnected"[^>]*>/, result)
+
+      assert tag =~ ~s(aria-hidden="true")
+
+      for {event, hidden} <- [{"phx-disconnected", "false"}, {"phx-connected", "true"}] do
+        [_, encoded] = Regex.run(~r/#{event}="([^"]+)"/, tag)
+        commands = encoded |> String.replace("&quot;", "\"") |> Jason.decode!()
+
+        assert ["set_attr", %{"attr" => ["aria-hidden", hidden], "to" => "#disconnected"}] in commands
+      end
+    end
+
     test "renders flash group with info message" do
       result =
         render_component(&dm_flash_group/1, %{


### PR DESCRIPTION
The reconnect toast remained an assertive alert in the accessibility tree while LiveView was connected because its visual toast state did not control accessibility visibility.

Start the reconnect toast with `aria-hidden="true"` and synchronize it with the existing disconnect/reconnect commands. The toast becomes accessible on disconnection and is hidden again on reconnection.

Validation: the regression failed before the fix; all 43 flash component tests and scoped compilation with warnings as errors pass. A committed Chromium regression executes the rendered commands through the real LiveView JS runtime and checks the accessibility tree in all three states.

Fixes #162
